### PR TITLE
Strip whitespace in alert regions

### DIFF
--- a/responseECS_LMDB2.py
+++ b/responseECS_LMDB2.py
@@ -2549,7 +2549,7 @@ def PW_Forecast(
 
                 alertDict = {
                     "title": alertDetails[0],
-                    "regions": alertDetails[2].split(";"),
+                    "regions": alertDetails[2].split(";").strip(),
                     "severity": alertDetails[5],
                     "time": int(
                         (


### PR DESCRIPTION
I know this repo is pretty outdated but I still thought it might be useful to help fix the whitespace issue reported here https://github.com/Pirate-Weather/pirateweather/issues/353