### PR TITLE
Apparent temperature fix

### DIFF
--- a/responseECS_LMDB2.py
+++ b/responseECS_LMDB2.py
@@ -1950,9 +1950,20 @@ def PW_Forecast(
     # Apparent Temperature, Radiative temperature formula
     # https: // github.com / breezy - weather / breezy - weather / discussions / 1085
     # AT = Ta + 0.33 × (rh / 100 × 6.105 × exp(17.27 × Ta / (237.7 + Ta))) − 0.70 × ws − 4.00
-    
-    e = InterPhour[:, 8] * 6.105 * np.exp(17.27 * (InterPhour[:, 5] - 273.15) / (237.7 + (InterPhour[:, 5] - 273.15)))
-    InterPcurrent[5] = ((InterPhour[:, 5] - 273.15) + 0.33 * e - 0.70 * (InterPhour[:, 10] / windUnit) - 4.00 ) + 273.15
+
+    e = (
+        InterPhour[:, 8]
+        * 6.105
+        * np.exp(
+            17.27 * (InterPhour[:, 5] - 273.15) / (237.7 + (InterPhour[:, 5] - 273.15))
+        )
+    )
+    InterPcurrent[5] = (
+        (InterPhour[:, 5] - 273.15)
+        + 0.33 * e
+        - 0.70 * (InterPhour[:, 10] / windUnit)
+        - 4.00
+    ) + 273.15
 
     ### Feels Like Temperature
     AppTemperatureHour = np.full((len(hour_array_grib), 2), np.nan)


### PR DESCRIPTION
@alexander0042 I was looking through the code and thought to compare the apparent temperature formula to the one in Breezy Weather. I noticed the one you setup didn't have water vapor pressure as a separate variable which is what I did here. If you prefer to have it all as one formula you just need to add brackets around the water vapor formula (`rh / 100 × 6.105 × exp(17.27 × Ta / (237.7 + Ta)`) and it will also fix the issue.