### PR TITLE
Change FireIndex cap to 100

### DIFF
--- a/API/responseLocal.py
+++ b/API/responseLocal.py
@@ -2718,7 +2718,7 @@ async def PW_Forecast(
 
     # Fire Index
     if "nbm_fire" in sourceList:
-        InterPhour[:, 24] = np.clip(NBM_Fire_Merged[:, 1], 0, 15)
+        InterPhour[:, 24] = np.clip(NBM_Fire_Merged[:, 1], 0, 100)
 
     # Apparent Temperature, Radiative temperature formula
     # https: // github.com / breezy - weather / breezy - weather / discussions / 1085


### PR DESCRIPTION
## Describe the change
I had previously changed the `fireIndex` on currently to be capped at 100 instead of 15 but I missed the hourly fireIndex. This PR also changes that to be capped at 100 instead of 15. Here's a [NOAA source](https://www.spc.noaa.gov/exper/firecomp/INFO/fosbinfo.html) which states that the cap is 100.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [x] I have signed the CLA agreement