### PR TITLE
Add back generic precipitation texts

### DIFF
--- a/API/PirateText.py
+++ b/API/PirateText.py
@@ -175,7 +175,7 @@ def calculate_text(
         else:
             cText = [mode, "heavy-sleet"]
             cCond = "heavy-sleet"
-    elif rainPrep > 0 and precipType == "none":
+    elif (rainPrep > 0 or snowPrep > 0 or icePrep > 0) and precipType == "none":
         if rainPrep < lightRainThresh:
             cText = [mode, possiblePrecip + "very-light-precipitation"]
             cCond = possiblePrecip + "very-light-precipitation"

--- a/API/PirateText.py
+++ b/API/PirateText.py
@@ -274,10 +274,7 @@ def calculate_text(
     if cIcon is None and cText is not None:
         if vis < visThresh:
             cIcon = "fog"
-        elif cloudCover > cloudThreshold:
-            cIcon = calculate_sky_icon(cloudCover, isDayTime)
-        elif cloudCover > partlyCloudyThreshold:
-            cIcon = calculate_sky_icon(cloudCover, isDayTime)
         else:
             cIcon = calculate_sky_icon(cloudCover, isDayTime)
+
     return cText, cIcon

--- a/API/PirateText.py
+++ b/API/PirateText.py
@@ -175,9 +175,22 @@ def calculate_text(
         else:
             cText = [mode, "heavy-sleet"]
             cCond = "heavy-sleet"
+    elif rainPrep > 0 and precipType == "none":
+        if rainPrep < lightRainThresh:
+            cText = [mode, possiblePrecip + "very-light-precipitation"]
+            cCond = possiblePrecip + "very-light-precipitation"
+        elif rainPrep >= lightRainThresh and rainPrep < midRainThresh:
+            cText = [mode, possiblePrecip + "light-precipitation"]
+            cCond = possiblePrecip + "light-precipitation"
+        elif rainPrep >= midRainThresh and rainPrep < heavyRainThresh:
+            cText = [mode, "medium-precipitation"]
+            cCond = "medium-precipitation"
+        else:
+            cText = [mode, "heavy-precipitation"]
+            cCond = "heavy-precipitation"
 
     # If visibility < 1000m, show fog
-    elif vis < visThresh:
+    elif vis < visThresh and wind < lightWindThresh:
         return [mode, "fog"], "fog"
     elif cloudCover > cloudThreshold:
         cText = [mode, "heavy-clouds"]


### PR DESCRIPTION
## Describe the change
This PR adds back the generic precipitation texts and changes it so the fog icon doesn't show if windy. Even though it shouldn't happen in theory it's still a good idea to have them here as a fallback. 

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [x] I have signed the CLA agreement