### PR TITLE
Add back zeroing intensity if HRRR subhourly not in list of sources

### DIFF
--- a/API/responseLocal.py
+++ b/API/responseLocal.py
@@ -2369,6 +2369,10 @@ async def PW_Forecast(
     else:  # GFS fallback
         InterPminute[:, 1] = gfsMinuteInterpolation[:, 10] * 3600 * prepIntensityUnit
 
+    if "hrrrsubh" not in sourceList:
+        # Set intensity to zero if POP == 0
+        InterPminute[InterPminute[:, 2] == 0, 1] = 0
+
     # "precipIntensityError"
     if "gefs" in sourceList:
         InterPminute[:, 3] = gefsMinuteInterpolation[:, 3] * prepIntensityUnit


### PR DESCRIPTION
## Describe the change
@alexander0042 Looks like one of the updates you pushed removing the code to zero out the intensity if pop is 0 in the currently/minutely section if HRRR subh not in the source list. You might have accidentally removed it when doing the GEFS change.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [x] I have signed the CLA agreement