### PR TITLE
Miscellaneous icon fixes

### DIFF
--- a/API/PirateWeeklyText.py
+++ b/API/PirateWeeklyText.py
@@ -70,8 +70,7 @@ def calculate_summary_text(
 
     # If the icon is not mixed precipitation change it to translations format
     if wIcon != "mixed-precipitation":
-        cIcon = wIcon
-        wIcon = calculate_precip_text(
+        wIcon, cIcon = calculate_precip_text(
             avgIntensity,
             intensityUnit,
             wIcon,
@@ -81,7 +80,7 @@ def calculate_summary_text(
             maxIntensity,
             1,
             icon,
-            "summary",
+            "both",
         )
     else:
         cIcon = "sleet"
@@ -322,7 +321,7 @@ def calculate_precip_summary(
             ]
         else:
             # If the types are not the same then set the icon to sleet and use the mixed precipitation text (as is how Dark Sky did it)
-            cIcon = "mixed"
+            cIcon = "sleet"
             precipSummary = ["for-week", "mixed-precipitation"]
 
     return precipSummary, cIcon

--- a/API/PirateWeeklyText.py
+++ b/API/PirateWeeklyText.py
@@ -84,7 +84,7 @@ def calculate_summary_text(
             "summary",
         )
     else:
-        cIcon = "mixed"
+        cIcon = "sleet"
 
     # If there are any days with thunderstorms occurring then calculate the text
     if numThunderstormDays > 0:


### PR DESCRIPTION
## Describe the change
Changed the weekly mixed precipitation icon from mixed to sleet to match the daily summaries and what Dark Sky did. We can introduce the mixed icon when we add in freezing rain/thunderstorms/hail.

Still need to debug why the weekly icon is incorrect when using the pirate weather icon set which is why this isn't ready to merge at the moment. When it's ready I will remove [skip ci] from the title so the actions run.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [x] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff