### PR TITLE
Update python requirements

### DIFF
--- a/Docker/requirements-api.txt
+++ b/Docker/requirements-api.txt
@@ -9,11 +9,11 @@ scipy==1.15.3
 orjson==3.10.18
 psutil==5.9.0
 typing-inspect==0.9.0
-watchfiles==1.0.5
+watchfiles==1.1.0
 dask==2025.5.1
-xarray==2025.4.0
+xarray==2025.6.1
 pandas==2.3.0
 fastparquet==2024.11.0
 pirateweather-translations==1.1
 s3fs==2025.5.1
-aiobotocore[boto3]==2.22.0
+aiobotocore[boto3]==2.23.0

--- a/Docker/requirements-ingest.txt
+++ b/Docker/requirements-ingest.txt
@@ -1,14 +1,14 @@
 numpy==2.2.6
-aiobotocore[boto3]==2.22.0
+aiobotocore[boto3]==2.23.0
 netCDF4==1.7.2
-xarray==2025.4.0
+xarray==2025.6.1
 cartopy==0.24.1
 cfgrib==0.9.15.0
 eccodes==2.41.0
 zarr==3.0.8
 dask==2025.5.1
 s3fs==2025.5.1
-bottleneck==1.4.2
+bottleneck==1.5.0
 rioxarray==0.19.0
 distributed==2025.5.1
 xarray-spatial==0.4.0


### PR DESCRIPTION
## Describe the change
Update the python requirements manually as numpy cannot be updated to 2.3 because of the following error:

```
ERROR: Cannot install -r requirements-ingest.txt (line 11), -r requirements-ingest.txt (line 12), -r requirements-ingest.txt (line 14), -r requirements-ingest.txt (line 15), -r requirements-ingest.txt (line 17), -r requirements-ingest.txt (line 19), -r requirements-ingest.txt (line 3), -r requirements-ingest.txt (line 4), -r requirements-ingest.txt (line 5), -r requirements-ingest.txt (line 6), -r requirements-ingest.txt (line 7), -r requirements-ingest.txt (line 8) and numpy==2.3.0 because these package versions have conflicting dependencies.
#29 11.66 
#29 11.66 The conflict is caused by:
#29 11.66     The user requested numpy==2.3.0
#29 11.66     herbie-data 2025.5.1.dev7+gfb40c86 depends on numpy>=1.24
#29 11.66     netcdf4 1.7.2 depends on numpy
#29 11.66     xarray 2025.6.1 depends on numpy>=1.24
#29 11.66     cartopy 0.24.1 depends on numpy>=1.23
#29 11.66     cfgrib 0.9.15.0 depends on numpy
#29 11.66     eccodes 2.41.0 depends on numpy
#29 11.66     zarr 3.0.8 depends on numpy>=1.25
#29 11.66     bottleneck 1.5.0 depends on numpy
#29 11.66     rioxarray 0.19.0 depends on numpy>=1.23
#29 11.66     xarray-spatial 0.4.0 depends on numpy
#29 11.66     geopandas 1.1.0 depends on numpy>=1.24
#29 11.66     numba 0.61.2 depends on numpy<2.3 and >=1.24
```

numba should have an update later this month to support numpy 2.3 so shall wait until then in order to update it @alexander0042 

## Type of change

- [ ] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [x] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff