### PR TITLE
Add S3 live forecast test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r Docker/requirements-api.txt
+          pip install pytest
+      - name: Run pytest
+        env:
+          PW_API: ${{ secrets.PW_API }}
+        run: pytest -q

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-python@v5.6.0
         with:
-          python-version: '3.12'
+          python-version: '3.13'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,10 @@
 name: Tests
 
 on:
-  push:
   pull_request:
-
+    branches: ['dev']
+  push:
+    branches-ignore: ['dev']
 jobs:
   pytest:
     runs-on: ubuntu-latest

--- a/tests/test_s3_live.py
+++ b/tests/test_s3_live.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 PW_API = os.environ.get("PW_API")
 
+
 @pytest.mark.skipif(not PW_API, reason="PW_API environment variable not set")
 def test_live_s3_forecast():
     os.environ["STAGE"] = "TESTING"
@@ -28,4 +29,3 @@ def test_live_s3_forecast():
     data = response.json()
     assert data["latitude"] == pytest.approx(45.0, abs=0.5)
     assert data["longitude"] == pytest.approx(-75.0, abs=0.5)
-

--- a/tests/test_s3_live.py
+++ b/tests/test_s3_live.py
@@ -1,0 +1,31 @@
+import os
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+PW_API = os.environ.get("PW_API")
+
+@pytest.mark.skipif(not PW_API, reason="PW_API environment variable not set")
+def test_live_s3_forecast():
+    os.environ["STAGE"] = "TESTING"
+    os.environ["save_type"] = "S3"
+    os.environ.setdefault("useETOPO", "FALSE")
+
+    # Load the responseLocal module directly from the API directory
+    api_path = Path(__file__).resolve().parents[1] / "API"
+    sys.path.insert(0, str(api_path))
+    response_path = api_path / "responseLocal.py"
+    spec = importlib.util.spec_from_file_location("responseLocal", response_path)
+    responseLocal = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(responseLocal)
+
+    client = TestClient(responseLocal.app)
+    response = client.get(f"/forecast/{PW_API}/45.0,-75.0")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["latitude"] == pytest.approx(45.0, abs=0.5)
+    assert data["longitude"] == pytest.approx(-75.0, abs=0.5)
+


### PR DESCRIPTION
## Summary
- add an empty `API/__init__.py` so the modules can be imported
- update the S3 live test to load `responseLocal.py` using an explicit path
- add a GitHub Actions workflow to run `pytest`

## Testing
- `PW_API=demo pytest -q` *(fails: ProxyConnectionError)*

------
https://chatgpt.com/codex/tasks/task_e_685d4f0cf110832d9d426a9c1c0e572e