### PR TITLE
Do not update numpy version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,9 @@ updates:
         - "minor"         # an array, possible values being minor, patch and major
         - "patch"
     open-pull-requests-limit: 100
+    ignore:
+      # Dependabot should not update numpy
+      - dependency-name: "numpy"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Describe the change
Change dependabot so it doesn't attempt to update numpy.

## Type of change

- [ ] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [x] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff