### PR TITLE
Update TimeMachine to 2.7.3 and fix ordering issues

### DIFF
--- a/API/timemachine.py
+++ b/API/timemachine.py
@@ -715,8 +715,8 @@ async def TimeMachine(
         hTextList.append(hourText)
         hourDict = {
             "time": int(InterPhour[idx, 0]) + halfTZ,
-            "icon": pIconList[idx],
             "summary": hourText,
+            "icon": pIconList[idx],
             "precipIntensity": round(InterPhour[idx, 1] * prepIntensityUnit, 2),
             "precipAccumulation": round(InterPhour[idx, 1] * prepAccumUnit, 4),
             "precipType": pTypeList[idx],
@@ -789,8 +789,8 @@ async def TimeMachine(
 
     dayDict = {
         "time": int(InterPhour[0, 0]) + halfTZ,
-        "icon": pIcon,
         "summary": pText,
+        "icon": pIcon,
         "sunriseTime": int(InterPday[16, 0]),
         "sunsetTime": int(InterPday[17, 0]),
         "moonPhase": round(InterPday[18, 0], 2),
@@ -905,7 +905,7 @@ async def TimeMachine(
         returnOBJ["flags"]["sources"] = "ERA5"
         returnOBJ["flags"]["nearest-station"] = int(0)
         returnOBJ["flags"]["units"] = unitSystem
-        returnOBJ["flags"]["version"] = "V2.5.4"
+        returnOBJ["flags"]["version"] = "V2.7.3"
         returnOBJ["flags"]["sourceIDX"] = {"x": y, "y": x}
         returnOBJ["flags"]["processTime"] = (
             datetime.datetime.utcnow() - T_Start


### PR DESCRIPTION
## Describe the change
PR to change the version of the TimeMachine endpoint to 2.7.3 (is showing 2.5.4 atm) and change the order of the text/summary to be inline with the API endpoint.

@alexander0042 Do we want to setup the new summaries for TimeMachine like we have for the API? The main issue will be the day summary as it goes from 12am-12am instead of 4am-4am so might make some weird summaries.

## Type of change

- [ ] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [x] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff