### PR TITLE
Move cleanup code

### DIFF
--- a/API/responseLocal.py
+++ b/API/responseLocal.py
@@ -4295,7 +4295,7 @@ async def PW_Forecast(
             for hourItem in hourList:
                 for field in fieldsToRemove:
                     hourItem.pop(field, None)
-        
+
         if extendFlag == 1:
             returnOBJ["hourly"]["data"] = hourList[
                 int(baseTimeOffset) : int(baseTimeOffset) + 169

--- a/API/responseLocal.py
+++ b/API/responseLocal.py
@@ -4350,7 +4350,7 @@ async def PW_Forecast(
         returnOBJ["flags"]["sourceTimes"] = sourceTimes
         returnOBJ["flags"]["nearest-station"] = int(0)
         returnOBJ["flags"]["units"] = unitSystem
-        returnOBJ["flags"]["version"] = "V2.7.5b"
+        returnOBJ["flags"]["version"] = "V2.7.5c"
         if version >= 2:
             returnOBJ["flags"]["sourceIDX"] = sourceIDX
             returnOBJ["flags"]["processTime"] = (

--- a/API/responseLocal.py
+++ b/API/responseLocal.py
@@ -3621,30 +3621,6 @@ async def PW_Forecast(
         dayTextList.append(dayObject["summary"])
         dayIconList.append(dayIcon)
 
-    # Final hourly cleanup.
-    fieldsToRemove = []
-
-    # Remove 'smoke' if the version is less than 2.
-    if version < 2:
-        fieldsToRemove.append("smoke")
-
-    # Remove extra fields for basic Time Machine requests.
-    if timeMachine and not tmExtra:
-        fieldsToRemove.extend(
-            [
-                "precipProbability",
-                "precipIntensityError",
-                "humidity",
-                "visibility",
-            ]
-        )
-
-    # Apply all identified removals to the final hourList.
-    if fieldsToRemove:
-        for hourItem in hourList:
-            for field in fieldsToRemove:
-                hourItem.pop(field, None)
-
     # Timing Check
     if TIMING:
         print("Alert Start")
@@ -4296,6 +4272,30 @@ async def PW_Forecast(
                     set(hourIconList), key=hourIconList.count
                 )
 
+        # Final hourly cleanup.
+        fieldsToRemove = []
+
+        # Remove 'smoke' if the version is less than 2.
+        if version < 2:
+            fieldsToRemove.append("smoke")
+
+        # Remove extra fields for basic Time Machine requests.
+        if timeMachine and not tmExtra:
+            fieldsToRemove.extend(
+                [
+                    "precipProbability",
+                    "precipIntensityError",
+                    "humidity",
+                    "visibility",
+                ]
+            )
+
+        # Apply all identified removals to the final hourList.
+        if fieldsToRemove:
+            for hourItem in hourList:
+                for field in fieldsToRemove:
+                    hourItem.pop(field, None)
+        
         if extendFlag == 1:
             returnOBJ["hourly"]["data"] = hourList[
                 int(baseTimeOffset) : int(baseTimeOffset) + 169

--- a/API/timemachine.py
+++ b/API/timemachine.py
@@ -983,7 +983,7 @@ async def TimeMachine(
         returnOBJ["flags"]["sources"] = "ERA5"
         returnOBJ["flags"]["nearest-station"] = int(0)
         returnOBJ["flags"]["units"] = unitSystem
-        returnOBJ["flags"]["version"] = "V2.7.5b"
+        returnOBJ["flags"]["version"] = "V2.7.5c"
         returnOBJ["flags"]["sourceIDX"] = {"x": y, "y": x}
         returnOBJ["flags"]["processTime"] = (
             datetime.datetime.utcnow() - T_Start


### PR DESCRIPTION
## Describe the change
Small PR to move the hourly cleanup function to before it gets included in the response to hopefully remove fields from showing when they shouldn't properly this time.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [x] The TimeMachine version (in API/timemachine.py) matches the API version number
