### PR TITLE
Fix inconsistencies in visibility thresholds

### DIFF
--- a/API/PirateTextHelper.py
+++ b/API/PirateTextHelper.py
@@ -498,7 +498,7 @@ def calculate_vis_text(
         visText = "fog"
         visIcon = "fog"
     # Smoke
-    elif smoke >= SMOKE_CONCENTRATION_THRESHOLD_UGM3 and vis <= mistThresh:
+    elif smoke >= SMOKE_CONCENTRATION_THRESHOLD_UGM3 and vis < mistThresh:
         visText = "smoke"
         visIcon = "smoke" if icon == "pirate" else "fog"
     # Mist
@@ -508,7 +508,7 @@ def calculate_vis_text(
     # Haze
     elif (
         smoke < SMOKE_CONCENTRATION_THRESHOLD_UGM3
-        and vis <= mistThresh
+        and vis < mistThresh
         and tempDewSpread > TEMP_DEWPOINT_SPREAD_FOR_MIST
     ):
         visText = "haze"


### PR DESCRIPTION
## Describe the change
When I was doing the docs changes for 2.7.5 I noticed an inconsistency in the visibility thresholds. Some were using less than while others were using less than or equal to. This changes everything to less than to make everything consistent.

@alexander0042 I know you just released the version but I only noticed this now so sorry about that.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [ ] The TimeMachine version (in API/timemachine.py) matches the API version number
