### PR TITLE
Change minutely `precipIntensity` to use reflectivity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r Docker/requirements-api.txt
+          pip install -r Docker/requirements-ingest.txt
           pip install pytest
       - name: Run pytest
         env:

--- a/API/GFS_Local_Ingest.py
+++ b/API/GFS_Local_Ingest.py
@@ -22,7 +22,12 @@ from xrspatial import direction, proximity
 
 from dask.diagnostics import ProgressBar
 
-from ingest_utils import mask_invalid_data, interp_time_block, validate_grib_stats
+from ingest_utils import (
+    mask_invalid_data,
+    interp_time_block,
+    validate_grib_stats,
+    mask_invalid_refc,
+)
 
 
 warnings.filterwarnings("ignore", "This pattern is interpreted")
@@ -366,9 +371,9 @@ APCP_surface_tmp[120:, :, :] = APCP_surface_tmp[120:, :, :] / 3
 xarray_forecast_merged["APCP_surface"].data = APCP_surface_tmp
 
 # Set REFC values < 5 to 0
-xarray_forecast_merged["REFC_entireatmosphere"] = xarray_forecast_merged[
-    "REFC_entireatmosphere"
-].where(xarray_forecast_merged["REFC_entireatmosphere"] >= 5, 0)
+xarray_forecast_merged["REFC_entireatmosphere"] = mask_invalid_refc(
+    xarray_forecast_merged["REFC_entireatmosphere"]
+)
 
 
 # Create a new xarray for storm distance processing using dask

--- a/API/GFS_Local_Ingest.py
+++ b/API/GFS_Local_Ingest.py
@@ -365,6 +365,11 @@ APCP_surface_tmp[120:, :, :] = APCP_surface_tmp[120:, :, :] / 3
 
 xarray_forecast_merged["APCP_surface"].data = APCP_surface_tmp
 
+# Set REFC values < 5 to 0
+xarray_forecast_merged["REFC_entireatmosphere"] = xarray_forecast_merged[
+    "REFC_entireatmosphere"
+].where(xarray_forecast_merged["REFC_entireatmosphere"] >= 5, 0)
+
 
 # Create a new xarray for storm distance processing using dask
 xarray_forecast_distance = xr.Dataset()

--- a/API/HRRR_6H_Local_Ingest.py
+++ b/API/HRRR_6H_Local_Ingest.py
@@ -294,6 +294,12 @@ xarray_forecast_merged["MASSDEN_8maboveground"] = (
     xarray_forecast_merged["MASSDEN_8maboveground"] * 1e9
 )
 
+# Set REFC values < 5 to 0
+xarray_forecast_merged["REFC_entireatmosphere"] = xarray_forecast_merged[
+    "REFC_entireatmosphere"
+].where(xarray_forecast_merged["REFC_entireatmosphere"] >= 5, 0)
+
+
 # Save the dataset with compression and filters for all variables
 compressor = Blosc(cname="lz4", clevel=1)
 filters = [BitRound(keepbits=12)]

--- a/API/HRRR_6H_Local_Ingest.py
+++ b/API/HRRR_6H_Local_Ingest.py
@@ -22,7 +22,7 @@ from herbie import FastHerbie, Path
 from herbie.fast import Herbie_latest
 from numcodecs import BitRound, Blosc
 
-from ingest_utils import mask_invalid_data, validate_grib_stats
+from ingest_utils import mask_invalid_data, validate_grib_stats, mask_invalid_refc
 
 
 warnings.filterwarnings("ignore", "This pattern is interpreted")
@@ -295,9 +295,9 @@ xarray_forecast_merged["MASSDEN_8maboveground"] = (
 )
 
 # Set REFC values < 5 to 0
-xarray_forecast_merged["REFC_entireatmosphere"] = xarray_forecast_merged[
-    "REFC_entireatmosphere"
-].where(xarray_forecast_merged["REFC_entireatmosphere"] >= 5, 0)
+xarray_forecast_merged["REFC_entireatmosphere"] = mask_invalid_refc(
+    xarray_forecast_merged["REFC_entireatmosphere"]
+)
 
 
 # Save the dataset with compression and filters for all variables

--- a/API/HRRR_Local_Ingest.py
+++ b/API/HRRR_Local_Ingest.py
@@ -20,7 +20,7 @@ import zarr.storage
 from herbie import FastHerbie, Path
 from herbie.fast import Herbie_latest
 
-from ingest_utils import mask_invalid_data, validate_grib_stats
+from ingest_utils import mask_invalid_data, validate_grib_stats, mask_invalid_refc
 
 warnings.filterwarnings("ignore", "This pattern is interpreted")
 
@@ -300,10 +300,9 @@ xarray_forecast_merged["MASSDEN_8maboveground"] = (
 )
 
 # Set REFC values < 5 to 0
-xarray_forecast_merged["REFC_entireatmosphere"] = xarray_forecast_merged[
-    "REFC_entireatmosphere"
-].where(xarray_forecast_merged["REFC_entireatmosphere"] >= 5, 0)
-
+xarray_forecast_merged["REFC_entireatmosphere"] = mask_invalid_refc(
+    xarray_forecast_merged["REFC_entireatmosphere"]
+)
 
 # %% Save merged and processed xarray dataset to disk using zarr with compression
 # Define the path to save the zarr dataset

--- a/API/HRRR_Local_Ingest.py
+++ b/API/HRRR_Local_Ingest.py
@@ -299,6 +299,12 @@ xarray_forecast_merged["MASSDEN_8maboveground"] = (
     xarray_forecast_merged["MASSDEN_8maboveground"] * 1e9
 )
 
+# Set REFC values < 5 to 0
+xarray_forecast_merged["REFC_entireatmosphere"] = xarray_forecast_merged[
+    "REFC_entireatmosphere"
+].where(xarray_forecast_merged["REFC_entireatmosphere"] >= 5, 0)
+
+
 # %% Save merged and processed xarray dataset to disk using zarr with compression
 # Define the path to save the zarr dataset
 

--- a/API/SubH_Local_Ingest.py
+++ b/API/SubH_Local_Ingest.py
@@ -20,7 +20,7 @@ import zarr
 from herbie import FastHerbie, Path
 from herbie.fast import Herbie_latest
 
-from ingest_utils import mask_invalid_data, validate_grib_stats
+from ingest_utils import mask_invalid_data, validate_grib_stats, mask_invalid_refc
 
 warnings.filterwarnings("ignore", "This pattern is interpreted")
 
@@ -273,9 +273,9 @@ xarray_forecast_merged = xr.open_mfdataset(forecast_process_path + "_wgrib2_merg
 
 
 # Set REFC values < 5 to 0
-xarray_forecast_merged["REFC_entireatmosphere"] = xarray_forecast_merged[
-    "REFC_entireatmosphere"
-].where(xarray_forecast_merged["REFC_entireatmosphere"] >= 5, 0)
+xarray_forecast_merged["REFC_entireatmosphere"] = mask_invalid_refc(
+    xarray_forecast_merged["REFC_entireatmosphere"]
+)
 
 if len(xarray_forecast_merged.time) != len(hrrr_range1) * 4:
     print(len(xarray_forecast_merged.time))

--- a/API/SubH_Local_Ingest.py
+++ b/API/SubH_Local_Ingest.py
@@ -271,6 +271,12 @@ if spOUT3.returncode != 0:
 # Read the netcdf file using xarray
 xarray_forecast_merged = xr.open_mfdataset(forecast_process_path + "_wgrib2_merged.nc")
 
+
+# Set REFC values < 5 to 0
+xarray_forecast_merged["REFC_entireatmosphere"] = xarray_forecast_merged[
+    "REFC_entireatmosphere"
+].where(xarray_forecast_merged["REFC_entireatmosphere"] >= 5, 0)
+
 if len(xarray_forecast_merged.time) != len(hrrr_range1) * 4:
     print(len(xarray_forecast_merged.time))
     print(len(hrrr_range1) * 4)

--- a/API/ingest_utils.py
+++ b/API/ingest_utils.py
@@ -12,6 +12,7 @@ from herbie import Path
 
 VALID_DATA_MIN = -100
 VALID_DATA_MAX = 120000
+REFC_THRESHOLD = 5.0
 
 
 def mask_invalid_data(daskArray, ignoreAxis=None):
@@ -26,6 +27,13 @@ def mask_invalid_data(daskArray, ignoreAxis=None):
         for i in ignoreAxis:
             valid_mask[i, :, :, :] = True
     return da.where(valid_mask, daskArray, np.nan)
+
+
+def mask_invalid_refc(xr_arr):
+    """
+    Masks REFC values less than 5, setting them to 0.
+    """
+    return xr_arr.where(xr_arr >= REFC_THRESHOLD, 0)
 
 
 # Linear interpolation of time blocks in a dask array

--- a/API/ingest_utils.py
+++ b/API/ingest_utils.py
@@ -3,7 +3,7 @@
 
 import re
 import sys
-
+import xarray as xr
 
 import dask.array as da
 import numpy as np
@@ -29,9 +29,14 @@ def mask_invalid_data(daskArray, ignoreAxis=None):
     return da.where(valid_mask, daskArray, np.nan)
 
 
-def mask_invalid_refc(xrArr):
-    """
-    Masks REFC values less than 5, setting them to 0.
+def mask_invalid_refc(xrArr: "xr.DataArray") -> "xr.DataArray":
+    """Masks REFC values less than 5, setting them to 0.
+
+    Args:
+        xrArr: The input xarray DataArray with REFC values.
+
+    Returns:
+        The masked xarray DataArray.
     """
     return xrArr.where(xrArr >= REFC_THRESHOLD, 0)
 

--- a/API/ingest_utils.py
+++ b/API/ingest_utils.py
@@ -29,11 +29,11 @@ def mask_invalid_data(daskArray, ignoreAxis=None):
     return da.where(valid_mask, daskArray, np.nan)
 
 
-def mask_invalid_refc(xr_arr):
+def mask_invalid_refc(xrArr):
     """
     Masks REFC values less than 5, setting them to 0.
     """
-    return xr_arr.where(xr_arr >= REFC_THRESHOLD, 0)
+    return xrArr.where(xrArr >= REFC_THRESHOLD, 0)
 
 
 # Linear interpolation of time blocks in a dask array

--- a/API/responseLocal.py
+++ b/API/responseLocal.py
@@ -54,7 +54,7 @@ force_now = os.getenv("force_now", default=False)
 
 # Version code for ingest files
 ingestVersion = "v27"
-API_VERSION = "V2.7.6"
+API_VERSION = "V2.7.7a"
 
 
 def setup_logging():


### PR DESCRIPTION
## Describe the change
Changes the minutely block to use reflectivity products for `precipIntensity` instead of relying on precipitation rate. @alexander0042 I think everything should be in order but just want to make sure Gemini didn't fuck anything up.

I only asked a few questions about where to add the sanity check (it's on ingest and response code since ingest changes won't be live on dev).

## Type of change

- [ ] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [x] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes https://github.com/Pirate-Weather/pirateweather/issues/390
- [ ] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [x] The TimeMachine version (in API/timemachine.py) matches the API version number
