### PR TITLE
Fix none precipitation not being counted as rain

### DIFF
--- a/API/responseLocal.py
+++ b/API/responseLocal.py
@@ -4292,7 +4292,7 @@ async def PW_Forecast(
     currnetSnowAccum = 0
     currnetIceAccum = 0
 
-    if minuteDict[0]["precipType"] == "rain":
+    if minuteDict[0]["precipType"] == "rain" or minuteDict[0]["precipType"] == "none":
         currnetRainAccum = (
             minuteDict[0]["precipIntensity"] / prepIntensityUnit * prepAccumUnit
         )

--- a/API/responseLocal.py
+++ b/API/responseLocal.py
@@ -53,7 +53,7 @@ force_now = os.getenv("force_now", default=False)
 
 # Version code for ingest files
 ingestVersion = "v27"
-API_VERSION = "V2.7.7c"
+API_VERSION = "V2.7.7d"
 
 
 def setup_logging():


### PR DESCRIPTION
## Describe the change
Fix none precipitation not being counted as rain so the rain icon would never show.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [ ] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [x] The TimeMachine version (in API/timemachine.py) matches the API version number
