### PR TITLE
Fix issues with reflectivity being in db not dbZ

### DIFF
--- a/API/constants/api_const.py
+++ b/API/constants/api_const.py
@@ -40,7 +40,7 @@ WBGT_CONST = {
 }
 
 # Grouped DBZ constants
-DBZ_CONST = {
+DB_CONST = {
     "rain_a": 200.0,
     "rain_b": 1.6,
     "snow_a": 600.0,

--- a/API/ingest_utils.py
+++ b/API/ingest_utils.py
@@ -10,8 +10,6 @@ import numpy as np
 import xarray as xr
 from herbie import Path
 
-from API.constants.shared_const import REFC_THRESHOLD
-
 # Shared ingest constants
 CHUNK_SIZES = {
     "NBM": 100,
@@ -57,6 +55,7 @@ FORECAST_LEAD_RANGES = {
 
 VALID_DATA_MIN = -100
 VALID_DATA_MAX = 120000
+REFC_THRESHOLD_INGEST = 0
 
 
 def mask_invalid_data(daskArray, ignoreAxis=None):
@@ -82,7 +81,7 @@ def mask_invalid_refc(xrArr: "xr.DataArray") -> "xr.DataArray":
     Returns:
         The masked xarray DataArray.
     """
-    return xrArr.where(xrArr >= REFC_THRESHOLD, 0)
+    return xrArr.where(xrArr >= REFC_THRESHOLD_INGEST, 0)
 
 
 # Linear interpolation of time blocks in a dask array


### PR DESCRIPTION
## Describe the change
Turns out reflectivity data is in db and not dbZ so the masking was removing valid data when it shouldn't have been. I changed the mask to filter everything below 0 and keeping the soft threshold as-is.

The failing tests seem to be unrelated to this PR? @alexander0042

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [ ] Code builds locally. **Your pull request won't be merged unless tests pass**
- [ ] Code has been formatted using ruff
- [ ] The TimeMachine version (in API/timemachine.py) matches the API version number
