### PR TITLE
Fix unitSystem regression

### DIFF
--- a/API/constants/api_const.py
+++ b/API/constants/api_const.py
@@ -66,7 +66,7 @@ PRECIP_IDX = {
 }
 
 # API versioning and ingest version constants
-API_VERSION = "V2.7.9"
+API_VERSION = "V2.7.10"
 
 # Command priorities
 NICE_PRIORITY = 20

--- a/API/responseLocal.py
+++ b/API/responseLocal.py
@@ -1470,6 +1470,8 @@ async def PW_Forecast(
             visUnits = 0.001  # km
             humidUnit = 0.01  # %
             elevUnit = 1  # m
+        else:
+            unitSystem = "us"
 
     weather = WeatherParallel()
 

--- a/API/timemachine.py
+++ b/API/timemachine.py
@@ -175,6 +175,8 @@ async def TimeMachine(
             tempUnits = KELVIN_TO_CELSIUS  # Celsius
             pressUnits = 0.01  # Hectopascals
             visUnits = 0.001  # km
+        else:
+            unitSystem = "us"
 
     if not exclude:
         excludeParams = ""


### PR DESCRIPTION
## Describe the change
Fix regression where invalid units were not being set to US in the response re https://github.com/Pirate-Weather/pirateweather/issues/512

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [x] The TimeMachine version (in API/timemachine.py) matches the API version number
