### PR TITLE
Remove base_time rounding as it causes issues

### DIFF
--- a/API/RTMA-RU_Local_Ingest.py
+++ b/API/RTMA-RU_Local_Ingest.py
@@ -2,7 +2,6 @@
 # Alexander Rey, September 2025
 
 # %% Import modules
-import datetime
 import logging
 import os
 import pickle
@@ -93,18 +92,6 @@ latest_run = Herbie_latest(
 )
 
 base_time = latest_run.date
-
-# Round base_time to nearest 15 minutes to ensure sourceTimes are exactly on :00, :15, :30, :45
-# Herbie may return times like :14, :29, :44, :59 due to data availability timing
-minute = base_time.minute
-rounded_minute = round(minute / 15) * 15
-if rounded_minute == 60:
-    base_time = base_time.replace(
-        minute=0, second=0, microsecond=0
-    ) + datetime.timedelta(hours=1)
-else:
-    base_time = base_time.replace(minute=rounded_minute, second=0, microsecond=0)
-
 logging.info(f"Checking for new RTMA_RU data for base time: {base_time}")
 
 # Check if this is newer than the current file


### PR DESCRIPTION
## Describe the change
Seems like it causes RTMA_RU ingest to fail so rollback to the working version

## Type of change

- [ ] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [x] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [x] The TimeMachine version (in API/timemachine.py) matches the API version number
