### PR TITLE
Refine production comparison tests

### DIFF
--- a/tests/test_compare_production.py
+++ b/tests/test_compare_production.py
@@ -39,13 +39,9 @@ def _fetch_production_json(url: str) -> dict:
 
     try:
         with urlopen(url, timeout=10) as response:
-            status_code = response.getcode()
             payload = response.read()
     except URLError as exc:  # pragma: no cover - network failure
-        raise ProductionRequestError(exc) from exc
-
-    if status_code != 200:
-        raise ProductionRequestError(f"Unexpected status {status_code} from {url}")
+        raise ProductionRequestError(f"Request to {url} failed: {exc}") from exc
 
     try:
         return json.loads(payload.decode("utf-8"))


### PR DESCRIPTION
## Summary
- replace the httpx client dependency with a urllib-based helper for production API calls
- surface clearer production request errors and reuse the helper for both forecast and timemachine checks
- pin the timemachine comparison to a June 2020 timestamp to satisfy historical coverage requirements

## Testing
- pytest tests/test_compare_production.py -k timemachine -vv *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_6904b9f15668832d8de123fa8699ec6b