### PR TITLE
Update herbie dependency to use PyPI instead of GitHub

### DIFF
--- a/Docker/requirements-ingest.txt
+++ b/Docker/requirements-ingest.txt
@@ -14,7 +14,7 @@ distributed==2025.10.0
 xarray-spatial==0.4.0
 geopandas==1.1.1
 nwswx==0.1.2
-git+https://github.com/blaylockbk/Herbie.git
+herbie-data==2025.11.0
 pyarrow==22.0.0
 numba==0.62.1
 metpy==1.7.1


### PR DESCRIPTION
## Describe the change
Change herbie to use the version on PyPI instead of using it directly from GitHub

## Type of change

- [ ] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [x] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #358
- [ ] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [x] The TimeMachine version (in API/timemachine.py) matches the API version number
