### PR TITLE
Add is_all_night flag to 24 hour summaries

### DIFF
--- a/API/responseLocal.py
+++ b/API/responseLocal.py
@@ -6097,7 +6097,7 @@ async def PW_Forecast(
             try:
                 hourIcon, hourText = calculate_day_text(
                     hourList_si[int(baseTimeOffset) : int(baseTimeOffset) + 24],
-                    True,
+                    not is_all_night,
                     str(tz_name),
                     int(time.time()),
                     "hour",


### PR DESCRIPTION
## Describe the change
Fix for the 24 hour summaries always using the day icons for polar night locations.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [x] The TimeMachine version (in API/timemachine.py) matches the API version number
