### PR TITLE
Handle missing alert end date

### DIFF
--- a/API/responseLocal.py
+++ b/API/responseLocal.py
@@ -5008,12 +5008,7 @@ async def PW_Forecast(
                     alertEnd = datetime.datetime.strptime(
                         wmo_alertDetails[4], "%Y-%m-%dT%H:%M:%S%z"
                     ).astimezone(utc)
-                    expires_ts = int(
-                        (
-                            alertEnd
-                            - datetime.datetime(1970, 1, 1, 0, 0, 0).astimezone(utc)
-                        ).total_seconds()
-                    )
+                    expires_ts = int(alertEnd.timestamp())
 
                 wmo_alertDict = {
                     "title": wmo_alertDetails[0],
@@ -5021,12 +5016,7 @@ async def PW_Forecast(
                         s.lstrip() for s in wmo_alertDetails[2].split(";") if s.strip()
                     ],
                     "severity": wmo_alertDetails[5],
-                    "time": int(
-                        (
-                            alertOnset
-                            - datetime.datetime(1970, 1, 1, 0, 0, 0).astimezone(utc)
-                        ).total_seconds()
-                    ),
+                    "time": int(alertOnset.timestamp()),
                     "expires": expires_ts,
                     "description": wmo_alertDetails[1],
                     "uri": wmo_alertDetails[6],

--- a/tests/test_compare_production.py
+++ b/tests/test_compare_production.py
@@ -96,7 +96,7 @@ def _diff_nested(a: object, b: object, path: str = "") -> dict:
 def test_local_vs_production():
     client = _get_client()
 
-    # Ottawa, ON (45.4215, -75.6972) and London, UK (51.50853, -0.12574)
+    # Ottawa, ON (45.4215, -75.6972) and Hong Kong (22.1875, 114.375)
     for lat, lon in [(45.4215, -75.6972), (22.1875, 114.375)]:
         local_resp = client.get(
             f"/forecast/{PW_API}/{lat},{lon}?version=2&include=day_night_forecast"


### PR DESCRIPTION
## Describe the change
If no alert end date set it to None to prevent the alert from going missing as per https://github.com/Pirate-Weather/pirate-weather-code/issues/368#issuecomment-3503985420

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [x] The TimeMachine version (in API/timemachine.py) matches the API version number
