### PR TITLE
Change expires timestamp to -999 to align with the rest of the API

### DIFF
--- a/API/constants/api_const.py
+++ b/API/constants/api_const.py
@@ -85,7 +85,7 @@ PRECIP_NOISE_THRESHOLD_MMH = (
 
 # API versioning and ingest version constants
 # Version scheme is: Major.Minor.Patch
-API_VERSION = "V2.8"
+API_VERSION = "V2.8.1a"
 
 # Command priorities
 NICE_PRIORITY = 20

--- a/API/responseLocal.py
+++ b/API/responseLocal.py
@@ -4998,7 +4998,7 @@ async def PW_Forecast(
                 # Format: event}{description}{area_desc}{effective}{expires}{severity}{URL
                 wmo_alertDetails = wmo_alert.split("}{")
                 alertEnd = None
-                expires_ts = None
+                expires_ts = -999
 
                 # Parse times - WMO times are in ISO format
                 alertOnset = datetime.datetime.strptime(


### PR DESCRIPTION
## Describe the change

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [x] The TimeMachine version (in API/timemachine.py) matches the API version number
