### PR TITLE
Change snow error calculations to run where type is snow and there is accumulation

### DIFF
--- a/API/PirateDailyText.py
+++ b/API/PirateDailyText.py
@@ -992,8 +992,8 @@ def calculate_day_text(
             # missing, fall back to using error directly.
             if (
                 not np.isnan(hour["precipIntensityError"])
-                and hour["precipType"] == "snow"
-                and hour["snowAccumulation"] > 0.0
+                and hour.get("precipType") == "snow"
+                and hour.get("snowAccumulation", 0.0) > 0.0
             ):
                 liquid_error_mm = hour["precipIntensityError"] * 1.0
                 temp = hour.get("temperature", MISSING_DATA)

--- a/API/PirateDayNightText.py
+++ b/API/PirateDayNightText.py
@@ -564,8 +564,8 @@ def calculate_half_day_text(
             # missing, fall back to using error directly.
             if (
                 not np.isnan(hour["precipIntensityError"])
-                and hour["precipType"] == "snow"
-                and hour["snowAccumulation"] > 0.0
+                and hour.get("precipType") == "snow"
+                and hour.get("snowAccumulation", 0.0) > 0.0
             ):
                 liquid_error_mm = hour["precipIntensityError"] * 1.0
                 temp = hour.get("temperature", MISSING_DATA)


### PR DESCRIPTION
## Describe the change
Before the snow error calculation took into account every hour even if the type wasn't snow and there was no accumulation. This PR fixes it so only hours with snow accumulation are counted toward the error.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [x] The TimeMachine version (in API/timemachine.py) matches the API version number
