### PR TITLE
Revert missing interp_time_take_blend

### DIFF
--- a/API/ingest_utils.py
+++ b/API/ingest_utils.py
@@ -1,5 +1,5 @@
 # %% Script to contain the helper functions as part of the data ingest for Pirate Weather
-# Alexander Rey. July 17 2025
+# Alexander Rey. July 2025
 
 import re
 import sys


### PR DESCRIPTION
## Describe the change
Emergency fix to correct broken ingest due to removal of mission critical function.

## Type of change

- [ ] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [ ] Code builds locally. **Your pull request won't be merged unless tests pass**
- [ ] Code has been formatted using ruff
- [ ] The TimeMachine version (in API/timemachine.py) matches the API version number
