### PR TITLE
Change snow_a constant value in DBZ_CONST from 600.0 to 300.0

### DIFF
--- a/API/constants/api_const.py
+++ b/API/constants/api_const.py
@@ -40,9 +40,12 @@ WBGT_CONST = {
 }
 
 # Grouped DBZ constants
+# Z-R relationships (Z = a * R^b) for converting radar reflectivity (Z) to precipitation rate (R).
 DBZ_CONST = {
+    # Based on the Marshall-Palmer relation for rain.
     "rain_a": 200.0,
     "rain_b": 1.6,
+    # Adjusted to provide higher snow rates. The previous value was 600.0.
     "snow_a": 300.0,
     "snow_b": 2.0,
 }


### PR DESCRIPTION
## Describe the change
Up the snow_a constant to 300 from 600 to give higher snow rates as I find the snowfall rates to be a bit low compared to rain.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [ ] The TimeMachine version (in API/timemachine.py) matches the API version number
