### PR TITLE
NBM regex fix

### DIFF
--- a/API/NBM_Local_Ingest.py
+++ b/API/NBM_Local_Ingest.py
@@ -482,7 +482,7 @@ if len(FH_forecastsub.file_exists) != len(nbm_range1):
 gribList1 = getGribList(FH_forecastsub, matchstring_pa)
 
 #####
-# Download PPROB as 6-Hour Accum for hours 036-190
+# Download 6-Hour Accum for hours 036-190
 
 # Create FastHerbie object
 FH_forecastsub2 = FastHerbie(


### PR DESCRIPTION
## Describe the change
So sorry this took so long, but finally worked out why the NBM ingest was/is failing. The regex parsing in the latest pandas/ eccodes version seems to have changed, and the end of line termination changed from "nan" to just the end of the line. This meant that most (but not all) of the grib products were not downloaded. Fixed in this PR

## Type of change

- [X] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes https://github.com/Pirate-Weather/pirate-weather-code/issues/530
- [ ] Code builds locally. **Your pull request won't be merged unless tests pass**
- [ ] Code has been formatted using ruff
- [ ] The TimeMachine version (in API/timemachine.py) matches the API version number
