### PR TITLE
fix typo in localstore GFS zarr filename

### DIFF
--- a/API/GFS_Local_Ingest.py
+++ b/API/GFS_Local_Ingest.py
@@ -1012,7 +1012,7 @@ if save_type == "S3":
         forecast_process_dir + "/GFS.zarr.zip", mode="a", compression=0
     )
 else:
-    zarr_store = zarr.storage.LocalStore(forecast_process_dir + "/GFS4.zarr")
+    zarr_store = zarr.storage.LocalStore(forecast_process_dir + "/GFS.zarr")
 
 
 #


### PR DESCRIPTION
## Describe the change
In API/GFS_Local_Ingest.py line 1015, the local zarr output filename is set in the LocalStore path, and in API/GFS_Local_Ingest.py line 1150 the script later copies from a hardcoded GFS.zarr path. The failure happens when these two hardcoded names differ (for example writing GFS4.zarr but copying GFS.zarr), which causes FileNotFoundError at copy time.
I've just renamed to be the same while I get familiar with the codebase, but further improvement would be to push this out into a global variable. 

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: #NA
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [x] The TimeMachine version (in API/timemachine.py) matches the API version number
