### PR TITLE
Fix hourly-daily indexing for DST

### DIFF
--- a/API/utils/time_indexing.py
+++ b/API/utils/time_indexing.py
@@ -182,6 +182,8 @@ def calculate_time_indexing(
         )
 
     # Replace missing values by forward-filling from the last valid day index.
+    # This handles hours that fall outside the expected day ranges, ensuring they are assigned to the most recent valid day index rather than being left as missing.
+    # For DST
     if np.any(np.isnan(hourly_day_index)):
         mask = np.isnan(hourly_day_index)
         idx = np.where(~mask, np.arange(len(hourly_day_index)), 0)


### PR DESCRIPTION
## Describe the change

Correct a nan value in the hourly/ daily indexing due to the start of daylight savings time

## Type of change

- [X] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [ ] Code builds locally. **Your pull request won't be merged unless tests pass**
- [ ] Code has been formatted using ruff
- [ ] The TimeMachine version (in API/timemachine.py) matches the API version number
