### PR TITLE
Change HRRR reflectivity to use 1km reflectivity for more accurate results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ venv/
 .venv/
 .vscode/settings.json
 my_venv/
+.hrrr.env

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,7 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
+
         {
             "name": "Python Debugger: FastAPI",
             "type": "debugpy",
@@ -71,6 +72,31 @@
                 "save_type": "Download",
                 "forecast_process_dir": "/mnt/nvme/data/SubH",
                 "forecast_path": "/mnt/nvme/data/Prod/SubH",
+                "ECCODES_DEFINITION_PATH": "/home/ubuntu/eccodes-2.40.0-Source/definitions/"
+            }
+        },
+        {
+            "name": "Python: HRRR_Local",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "API.HRRR_Local_Ingest",
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}",
+            "justMyCode": true,
+            "envFile": "${workspaceFolder}/.hrrr.env"
+        },
+        {
+            "name": "Python: HRRR_6H_Local",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "API.HRRR_6H_Local_Ingest",
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}",
+            "justMyCode": true,
+            "env": {
+                "save_type": "Download",
+                "forecast_process_dir": "/mnt/nvme/data/HRRR_6H",
+                "forecast_path": "/mnt/nvme/data/Prod/HRRR_6H",
                 "ECCODES_DEFINITION_PATH": "/home/ubuntu/eccodes-2.40.0-Source/definitions/"
             }
         },

--- a/API/ECMWF_Local_Ingest.py
+++ b/API/ECMWF_Local_Ingest.py
@@ -39,6 +39,7 @@ from API.ingest_utils import (
     run_command,
     tune_nofile_limit,
     validate_grib_stats,
+    check_historic_zarr,
 )
 
 warnings.filterwarnings("ignore", "This pattern is interpreted")
@@ -494,50 +495,39 @@ print(T1 - T0)
 
 # 6 hour runs
 for i in range(his_period, 1, -12):
+    zarr_path = (
+        historic_path
+        + "/ECMWF_Hist"
+        + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")
+        + ".zarr"
+    )
+    s3_path = zarr_path
+    local_path = zarr_path
+    done_file = zarr_path.replace(".zarr", ".done")
+
+    file_exists = False
+    
     if save_type == "S3":
-        # S3 Path Setup
-        s3_path = (
-            historic_path
-            + "/ECMWF_Hist"
-            + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")
-            + ".zarr"
-        )
-        if s3.exists(s3_path.replace(".zarr", ".done")):
-            print("File already exists in S3, skipping download for: " + s3_path)
-            # If the file exists, check that it works
-
-            # Try to open and read data from the last variable of the zarr file to check if it has already been saved
-            try:
-                hisCheckStore = zarr.storage.FsspecStore.from_url(
-                    s3_path,
-                    storage_options={
-                        "key": aws_access_key_id,
-                        "secret": aws_secret_access_key,
-                    },
-                )
-                zarr.open(hisCheckStore)[zarr_vars[-1]][-1, -1, -1]
-                continue  # If it exists, skip to the next iteration
-            except Exception:
-                print("### Historic Data Failure!")
-                print(traceback.print_exc())
-
-                # Delete the file if it exists
-                if s3.exists(s3_path):
-                    s3.rm(s3_path)
-
+        if s3.exists(done_file):
+            print(f"File already exists in S3, checking integrity for: {zarr_path}")
+            file_exists = True
     else:
-        # Local Path Setup
-        local_path = (
-            historic_path
-            + "/ECMWF_Hist"
-            + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")
-            + ".zarr"
-        )
+        if os.path.exists(done_file):
+            print(f"File already exists locally, checking integrity for: {zarr_path}")
+            file_exists = True
 
-        # Check for a loca done file
-        if os.path.exists(local_path.replace(".zarr", ".done")):
-            print("File already exists in S3, skipping download for: " + local_path)
+    if file_exists:
+        if check_historic_zarr(
+            zarr_path,
+            save_type,
+            zarr_vars,
+            aws_access_key_id,
+            aws_secret_access_key,
+        ):
+            print("Integrity check passed, skipping download for: " + zarr_path)
             continue
+        else:
+            print("Integrity check failed, file deleted. Redownloading for: " + zarr_path)
 
     print(
         "Downloading: " + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")

--- a/API/ECMWF_Local_Ingest.py
+++ b/API/ECMWF_Local_Ingest.py
@@ -11,7 +11,6 @@ import pickle
 import shutil
 import sys
 import time
-import traceback
 import warnings
 
 import dask
@@ -31,6 +30,7 @@ from API.ingest_utils import (
     FORECAST_LEAD_RANGES,
     VALID_DATA_MAX,
     VALID_DATA_MIN,
+    check_historic_zarr,
     close_store,
     configure_zarr_limits,
     interp_time_take_blend,
@@ -39,7 +39,6 @@ from API.ingest_utils import (
     run_command,
     tune_nofile_limit,
     validate_grib_stats,
-    check_historic_zarr,
 )
 
 warnings.filterwarnings("ignore", "This pattern is interpreted")
@@ -506,7 +505,7 @@ for i in range(his_period, 1, -12):
     done_file = zarr_path.replace(".zarr", ".done")
 
     file_exists = False
-    
+
     if save_type == "S3":
         if s3.exists(done_file):
             print(f"File already exists in S3, checking integrity for: {zarr_path}")
@@ -527,7 +526,9 @@ for i in range(his_period, 1, -12):
             print("Integrity check passed, skipping download for: " + zarr_path)
             continue
         else:
-            print("Integrity check failed, file deleted. Redownloading for: " + zarr_path)
+            print(
+                "Integrity check failed, file deleted. Redownloading for: " + zarr_path
+            )
 
     print(
         "Downloading: " + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")

--- a/API/GEFS_Local_Ingest.py
+++ b/API/GEFS_Local_Ingest.py
@@ -7,7 +7,6 @@ import pickle
 import shutil
 import sys
 import time
-import traceback
 import warnings
 
 import dask
@@ -26,6 +25,7 @@ from API.ingest_utils import (
     CHUNK_SIZES,
     FINAL_CHUNK_SIZES,
     FORECAST_LEAD_RANGES,
+    check_historic_zarr,
     configure_zarr_limits,
     interp_time_take_blend,
     mask_invalid_data,
@@ -34,7 +34,6 @@ from API.ingest_utils import (
     run_command,
     tune_nofile_limit,
     validate_grib_stats,
-    check_historic_zarr,
 )
 
 warnings.filterwarnings("ignore", "This pattern is interpreted")
@@ -429,7 +428,7 @@ for i in range(his_period, 0, -6):
     done_file = zarr_path.replace(".zarr", ".done")
 
     file_exists = False
-    
+
     if save_type == "S3":
         if s3.exists(done_file):
             print(f"File already exists in S3, checking integrity for: {zarr_path}")
@@ -450,7 +449,9 @@ for i in range(his_period, 0, -6):
             print("Integrity check passed, skipping download for: " + zarr_path)
             continue
         else:
-            print("Integrity check failed, file deleted. Redownloading for: " + zarr_path)
+            print(
+                "Integrity check failed, file deleted. Redownloading for: " + zarr_path
+            )
 
     print(
         "Downloading: " + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")

--- a/API/GEFS_Local_Ingest.py
+++ b/API/GEFS_Local_Ingest.py
@@ -34,6 +34,7 @@ from API.ingest_utils import (
     run_command,
     tune_nofile_limit,
     validate_grib_stats,
+    check_historic_zarr,
 )
 
 warnings.filterwarnings("ignore", "This pattern is interpreted")
@@ -417,51 +418,40 @@ def preprocess(ds):
 for i in range(his_period, 0, -6):
     # s3_path_NC = s3_bucket + '/GEFS/GEFS_HistProb_' + (base_time - pd.Timedelta(hours = i)).strftime('%Y%m%dT%H%M%SZ') + '.nc'
 
-    # Try to open the zarr file to check if it has already been saved
+    zarr_path = (
+        historic_path
+        + "/GEFS_HistProb_"
+        + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")
+        + ".zarr"
+    )
+    s3_path = zarr_path
+    local_path = zarr_path
+    done_file = zarr_path.replace(".zarr", ".done")
+
+    file_exists = False
+    
     if save_type == "S3":
-        # Create the S3 filesystem
-        s3_path = (
-            historic_path
-            + "/GEFS_HistProb_"
-            + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")
-            + ".zarr"
-        )
-
-        # Check for a done file in S3
-        if s3.exists(s3_path.replace(".zarr", ".done")):
-            print("File already exists in S3, skipping download for: " + s3_path)
-
-            # If the file exists, check that it works
-            try:
-                hisCheckStore = zarr.storage.FsspecStore.from_url(
-                    s3_path,
-                    storage_options={
-                        "key": aws_access_key_id,
-                        "secret": aws_secret_access_key,
-                    },
-                )
-                zarr.open(hisCheckStore)[probVars[-1]][-1, -1, -1]
-                continue  # If it exists, skip to the next iteration
-            except Exception:
-                print("### Historic Data Failure!")
-                print(traceback.print_exc())
-
-                # Delete the file if it exists
-                if s3.exists(s3_path):
-                    s3.rm(s3_path)
+        if s3.exists(done_file):
+            print(f"File already exists in S3, checking integrity for: {zarr_path}")
+            file_exists = True
     else:
-        # Local Path Setup
-        local_path = (
-            historic_path
-            + "/GEFS_HistProb_"
-            + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")
-            + ".zarr"
-        )
+        if os.path.exists(done_file):
+            print(f"File already exists locally, checking integrity for: {zarr_path}")
+            file_exists = True
 
-        # Check for a loca done file
-        if os.path.exists(local_path.replace(".zarr", ".done")):
-            print("File already exists in S3, skipping download for: " + local_path)
+    if file_exists:
+        if check_historic_zarr(
+            zarr_path,
+            save_type,
+            probVars,
+            aws_access_key_id,
+            aws_secret_access_key,
+        ):
+            print("Integrity check passed, skipping download for: " + zarr_path)
             continue
+        else:
+            print("Integrity check failed, file deleted. Redownloading for: " + zarr_path)
+
     print(
         "Downloading: " + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")
     )

--- a/API/GFS_Local_Ingest.py
+++ b/API/GFS_Local_Ingest.py
@@ -7,7 +7,6 @@ import pickle
 import shutil
 import sys
 import time
-import traceback
 import warnings
 
 import dask
@@ -27,6 +26,7 @@ from API.ingest_utils import (
     FINAL_CHUNK_SIZES,
     FORECAST_LEAD_RANGES,
     build_herbie_grib_list,
+    check_historic_zarr,
     close_store,
     configure_zarr_limits,
     interp_time_take_blend,
@@ -38,7 +38,6 @@ from API.ingest_utils import (
     run_command,
     tune_nofile_limit,
     validate_grib_stats,
-    check_historic_zarr,
 )
 
 warnings.filterwarnings("ignore", "This pattern is interpreted")
@@ -578,7 +577,7 @@ for i in range(his_period, 0, -6):
     done_file = zarr_path.replace(".zarr", ".done")
 
     file_exists = False
-    
+
     if save_type == "S3":
         if s3.exists(done_file):
             print(f"File already exists in S3, checking integrity for: {zarr_path}")
@@ -599,7 +598,9 @@ for i in range(his_period, 0, -6):
             print("Integrity check passed, skipping download for: " + zarr_path)
             continue
         else:
-            print("Integrity check failed, file deleted. Redownloading for: " + zarr_path)
+            print(
+                "Integrity check failed, file deleted. Redownloading for: " + zarr_path
+            )
 
     print(
         "Downloading: " + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")

--- a/API/GFS_Local_Ingest.py
+++ b/API/GFS_Local_Ingest.py
@@ -38,6 +38,7 @@ from API.ingest_utils import (
     run_command,
     tune_nofile_limit,
     validate_grib_stats,
+    check_historic_zarr,
 )
 
 warnings.filterwarnings("ignore", "This pattern is interpreted")
@@ -566,48 +567,39 @@ os.remove(forecast_process_path + "_wgrib2_merged.nc")
 
 # 6 hour runs
 for i in range(his_period, 0, -6):
+    zarr_path = (
+        historic_path
+        + "/GFS_Hist_v2"
+        + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")
+        + ".zarr"
+    )
+    s3_path = zarr_path
+    local_path = zarr_path
+    done_file = zarr_path.replace(".zarr", ".done")
+
+    file_exists = False
+    
     if save_type == "S3":
-        s3_path = (
-            historic_path
-            + "/GFS_Hist_v2"
-            + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")
-            + ".zarr"
-        )
-
-        # Check for a done file in S3
-        if s3.exists(s3_path.replace(".zarr", ".done")):
-            print("File already exists in S3, skipping download for: " + s3_path)
-            # If the file exists, check that it works
-            try:
-                hisCheckStore = zarr.storage.FsspecStore.from_url(
-                    s3_path,
-                    storage_options={
-                        "key": aws_access_key_id,
-                        "secret": aws_secret_access_key,
-                    },
-                )
-                zarr.open(hisCheckStore)[zarr_vars[-1]][-1, -1, -1]
-                continue  # If it exists, skip to the next iteration
-            except Exception:
-                print("### Historic Data Failure!")
-                print(traceback.print_exc())
-
-                # Delete the file if it exists
-                if s3.exists(s3_path):
-                    s3.rm(s3_path)
+        if s3.exists(done_file):
+            print(f"File already exists in S3, checking integrity for: {zarr_path}")
+            file_exists = True
     else:
-        # Local Path Setup
-        local_path = (
-            historic_path
-            + "/GFS_Hist_v2"
-            + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")
-            + ".zarr"
-        )
+        if os.path.exists(done_file):
+            print(f"File already exists locally, checking integrity for: {zarr_path}")
+            file_exists = True
 
-        # Check for a loca done file
-        if os.path.exists(local_path.replace(".zarr", ".done")):
-            print("File already exists in S3, skipping download for: " + local_path)
+    if file_exists:
+        if check_historic_zarr(
+            zarr_path,
+            save_type,
+            zarr_vars,
+            aws_access_key_id,
+            aws_secret_access_key,
+        ):
+            print("Integrity check passed, skipping download for: " + zarr_path)
             continue
+        else:
+            print("Integrity check failed, file deleted. Redownloading for: " + zarr_path)
 
     print(
         "Downloading: " + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")

--- a/API/HRRR_6H_Local_Ingest.py
+++ b/API/HRRR_6H_Local_Ingest.py
@@ -173,11 +173,11 @@ matchstring_8m = ":(MASSDEN:8 m above ground:)"
 matchstring_su = (
     ":((CRAIN|CICEP|CSNOW|CFRZR|PRATE|VIS|GUST|DSWRF|CAPE):surface:.*hour fcst)"
 )
-matchstring_1000m = "(:REFD:1000 m above ground:)"
 matchstring_10m = "(:(UGRD|VGRD):10 m above ground:.*hour fcst)"
 matchstring_cl = "(:TCDC:entire atmosphere:.*hour fcst)"
 matchstring_ap = "(:APCP:surface:0-[1-9]*)"
 matchstring_sl = "(:(MSLMA):)"
+matchstring_1000m = "(:REFD:1000 m above ground:)"
 
 # Merge matchstrings for download
 match_strings = (
@@ -187,8 +187,6 @@ match_strings = (
     + "|"
     + matchstring_10m
     + "|"
-    + matchstring_1000m
-    + "|"
     + matchstring_cl
     + "|"
     + matchstring_ap
@@ -196,6 +194,8 @@ match_strings = (
     + matchstring_8m
     + "|"
     + matchstring_sl
+    + "|"
+    + matchstring_1000m
 )
 
 # Create a range of forecast lead times

--- a/API/HRRR_6H_Local_Ingest.py
+++ b/API/HRRR_6H_Local_Ingest.py
@@ -156,7 +156,7 @@ zarr_vars = (
     "CRAIN_surface",
     "TCDC_entireatmosphere",
     "MASSDEN_8maboveground",
-    "REFC_entireatmosphere",
+    "REFD_1000maboveground",
     "DSWRF_surface",
     "CAPE_surface",
 )
@@ -173,10 +173,11 @@ matchstring_8m = ":(MASSDEN:8 m above ground:)"
 matchstring_su = (
     ":((CRAIN|CICEP|CSNOW|CFRZR|PRATE|VIS|GUST|DSWRF|CAPE):surface:.*hour fcst)"
 )
+matchstring_1000m = "(:REFD:1000 m above ground:)"
 matchstring_10m = "(:(UGRD|VGRD):10 m above ground:.*hour fcst)"
 matchstring_cl = "(:TCDC:entire atmosphere:.*hour fcst)"
 matchstring_ap = "(:APCP:surface:0-[1-9]*)"
-matchstring_sl = "(:(MSLMA|REFC):)"
+matchstring_sl = "(:(MSLMA):)"
 
 # Merge matchstrings for download
 match_strings = (
@@ -185,6 +186,8 @@ match_strings = (
     + matchstring_su
     + "|"
     + matchstring_10m
+    + "|"
+    + matchstring_1000m
     + "|"
     + matchstring_cl
     + "|"
@@ -321,9 +324,9 @@ xarray_forecast_merged["MASSDEN_8maboveground"] = (
     xarray_forecast_merged["MASSDEN_8maboveground"] * 1e9
 )
 
-# Set REFC values < 5 to 0
-xarray_forecast_merged["REFC_entireatmosphere"] = mask_invalid_refc(
-    xarray_forecast_merged["REFC_entireatmosphere"]
+# Set REFD values < 5 to 0
+xarray_forecast_merged["REFD_1000maboveground"] = mask_invalid_refc(
+    xarray_forecast_merged["REFD_1000maboveground"]
 )
 
 

--- a/API/HRRR_Local_Ingest.py
+++ b/API/HRRR_Local_Ingest.py
@@ -173,11 +173,11 @@ matchstring_8m = ":(MASSDEN:8 m above ground:)"
 matchstring_su = (
     ":((CRAIN|CICEP|CSNOW|CFRZR|PRATE|VIS|GUST|DSWRF|CAPE):surface:.*hour fcst)"
 )
-matchstring_1000m = "(:REFD:1000 m above ground:)"
 matchstring_10m = "(:(UGRD|VGRD):10 m above ground:.*hour fcst)"
 matchstring_cl = "(:TCDC:entire atmosphere:.*hour fcst)"
 matchstring_ap = "(:APCP:surface:0-[1-9]*)"
 matchstring_sl = "(:(MSLMA):)"
+matchstring_1000m = "(:REFD:1000 m above ground:)"
 
 # Merge matchstrings for download
 match_strings = (
@@ -187,8 +187,6 @@ match_strings = (
     + "|"
     + matchstring_10m
     + "|"
-    + matchstring_1000m
-    + "|"
     + matchstring_cl
     + "|"
     + matchstring_ap
@@ -196,6 +194,8 @@ match_strings = (
     + matchstring_8m
     + "|"
     + matchstring_sl
+    + "|"
+    + matchstring_1000m
 )
 
 # Create a range of forecast lead times

--- a/API/HRRR_Local_Ingest.py
+++ b/API/HRRR_Local_Ingest.py
@@ -25,6 +25,7 @@ from API.ingest_utils import (
     CHUNK_SIZES,
     FINAL_CHUNK_SIZES,
     FORECAST_LEAD_RANGES,
+    check_historic_zarr,
     close_store,
     configure_zarr_limits,
     mask_invalid_data,
@@ -376,59 +377,39 @@ print("FORECAST COMPLETE")
 for i in range(his_period, -1, -1):
     # Define the path to save the zarr dataset with the run time in the filename
     # format the time following iso8601
-    s3_path = (
+    zarr_path = (
         historic_path
         + "/HRRR_Hist_v2"
         + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")
         + ".zarr"
     )
-
-    # Try to open the zarr file to check if it has already been saved
+    s3_path = zarr_path
+    local_path = zarr_path
+    done_file = zarr_path.replace(".zarr", ".done")
+    
+    file_exists = False
+    
     if save_type == "S3":
-        # Create the S3 filesystem
-        s3_path = (
-            historic_path
-            + "/HRRR_Hist_v2"
-            + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")
-            + ".zarr"
-        )
-        if s3.exists(s3_path.replace(".zarr", ".done")):
-            print("File already exists in S3, skipping download for: " + s3_path)
-            # If the file exists, check that it works
-
-            if s3.exists(s3_path):
-                # Try to open and read data from the last variable of the zarr file to check if it has already been saved
-                try:
-                    hisCheckStore = zarr.storage.FsspecStore.from_url(
-                        s3_path,
-                        storage_options={
-                            "key": aws_access_key_id,
-                            "secret": aws_secret_access_key,
-                        },
-                    )
-                    zarr.open(hisCheckStore)[zarr_vars[-1]][-1, -1, -1]
-                    continue  # If it exists, skip to the next iteration
-                except Exception:
-                    print("### Historic Data Failure!")
-                    print(traceback.print_exc())
-
-                    # Delete the file if it exists
-                    if s3.exists(s3_path):
-                        s3.rm(s3_path)
-
+        if s3.exists(done_file):
+            print(f"File already exists in S3, checking integrity for: {zarr_path}")
+            file_exists = True
     else:
-        # Local Path Setup
-        local_path = (
-            historic_path
-            + "/HRRR_Hist_v2"
-            + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")
-            + ".zarr"
-        )
+        if os.path.exists(done_file):
+            print(f"File already exists locally, checking integrity for: {zarr_path}")
+            file_exists = True
 
-        # Check for a loca done file
-        if os.path.exists(local_path.replace(".zarr", ".done")):
-            print("File already exists in S3, skipping download for: " + local_path)
+    if file_exists:
+        if check_historic_zarr(
+            zarr_path,
+            save_type,
+            zarr_vars,
+            aws_access_key_id,
+            aws_secret_access_key,
+        ):
+            print("Integrity check passed, skipping download for: " + zarr_path)
             continue
+        else:
+            print("Integrity check failed, file deleted. Redownloading for: " + zarr_path)
 
     print(
         "Downloading: " + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")

--- a/API/HRRR_Local_Ingest.py
+++ b/API/HRRR_Local_Ingest.py
@@ -157,7 +157,7 @@ zarr_vars = (
     "CRAIN_surface",
     "TCDC_entireatmosphere",
     "MASSDEN_8maboveground",
-    "REFC_entireatmosphere",
+    "REFD_1000maboveground",
     "DSWRF_surface",
     "CAPE_surface",
 )
@@ -173,10 +173,11 @@ matchstring_8m = ":(MASSDEN:8 m above ground:)"
 matchstring_su = (
     ":((CRAIN|CICEP|CSNOW|CFRZR|PRATE|VIS|GUST|DSWRF|CAPE):surface:.*hour fcst)"
 )
+matchstring_1000m = "(:REFD:1000 m above ground:)"
 matchstring_10m = "(:(UGRD|VGRD):10 m above ground:.*hour fcst)"
 matchstring_cl = "(:TCDC:entire atmosphere:.*hour fcst)"
 matchstring_ap = "(:APCP:surface:0-[1-9]*)"
-matchstring_sl = "(:(MSLMA|REFC):)"
+matchstring_sl = "(:(MSLMA):)"
 
 # Merge matchstrings for download
 match_strings = (
@@ -185,6 +186,8 @@ match_strings = (
     + matchstring_su
     + "|"
     + matchstring_10m
+    + "|"
+    + matchstring_1000m
     + "|"
     + matchstring_cl
     + "|"
@@ -326,9 +329,9 @@ xarray_forecast_merged["MASSDEN_8maboveground"] = (
 )
 
 
-# Set REFC values < 5 to 0
-xarray_forecast_merged["REFC_entireatmosphere"] = mask_invalid_refc(
-    xarray_forecast_merged["REFC_entireatmosphere"]
+# Set REFD values < 5 to 0
+xarray_forecast_merged["REFD_1000maboveground"] = mask_invalid_refd(
+    xarray_forecast_merged["REFD_1000maboveground"]
 )
 
 # %% Save merged and processed xarray dataset to disk using zarr with compression
@@ -705,7 +708,7 @@ close_store(zarr_store)
 # 9 (PRATE)
 # 11:14 (PTYPE)
 # 16 (MASSDEN)
-# 17 (REFC)
+# 17 (REFD)
 
 # Add padding for map chunking (100x100)
 daskVarArrayStackDisk_maps = pad_to_chunk_size(daskVarArrayStackDisk, 100)

--- a/API/HRRR_Local_Ingest.py
+++ b/API/HRRR_Local_Ingest.py
@@ -261,9 +261,6 @@ if sp_out.returncode != 0:
     print(sp_out.stderr)
     sys.exit()
 
-# Check output from wgrib2
-# print(sp_out.stdout)
-
 # Use wgrib2 to rotate the wind vectors
 # From https://github.com/blaylockbk/pyBKB_v2/blob/master/demos/HRRR_earthRelative_vs_gridRelative_winds.ipynb
 lambertRotation = "lambert:262.500000:38.500000:38.500000:38.500000 237.280472:1799:3000.000000 21.138123:1059:3000.000000"

--- a/API/HRRR_Local_Ingest.py
+++ b/API/HRRR_Local_Ingest.py
@@ -330,7 +330,7 @@ xarray_forecast_merged["MASSDEN_8maboveground"] = (
 
 
 # Set REFD values < 5 to 0
-xarray_forecast_merged["REFD_1000maboveground"] = mask_invalid_refd(
+xarray_forecast_merged["REFD_1000maboveground"] = mask_invalid_refc(
     xarray_forecast_merged["REFD_1000maboveground"]
 )
 

--- a/API/HRRR_Local_Ingest.py
+++ b/API/HRRR_Local_Ingest.py
@@ -7,7 +7,6 @@ import pickle
 import shutil
 import sys
 import time
-import traceback
 import warnings
 
 import dask
@@ -386,9 +385,9 @@ for i in range(his_period, -1, -1):
     s3_path = zarr_path
     local_path = zarr_path
     done_file = zarr_path.replace(".zarr", ".done")
-    
+
     file_exists = False
-    
+
     if save_type == "S3":
         if s3.exists(done_file):
             print(f"File already exists in S3, checking integrity for: {zarr_path}")
@@ -409,7 +408,9 @@ for i in range(his_period, -1, -1):
             print("Integrity check passed, skipping download for: " + zarr_path)
             continue
         else:
-            print("Integrity check failed, file deleted. Redownloading for: " + zarr_path)
+            print(
+                "Integrity check failed, file deleted. Redownloading for: " + zarr_path
+            )
 
     print(
         "Downloading: " + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")

--- a/API/NBM_Fire_Local_Ingest.py
+++ b/API/NBM_Fire_Local_Ingest.py
@@ -35,6 +35,7 @@ from API.ingest_utils import (
     run_command,
     tune_nofile_limit,
     validate_grib_stats,
+    check_historic_zarr,
 )
 
 
@@ -437,47 +438,39 @@ for i in range(his_period, 1, -6):
     # Define the path to save the zarr dataset with the run time in the filename
     # format the time following iso8601
 
+    zarr_path = (
+        historic_path
+        + "/NBM_Fire_Hist"
+        + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")
+        + ".zarr"
+    )
+    s3_path = zarr_path
+    local_path = zarr_path
+    done_file = zarr_path.replace(".zarr", ".done")
+
+    file_exists = False
+    
     if save_type == "S3":
-        s3_path = (
-            historic_path
-            + "/NBM_Fire_Hist"
-            + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")
-            + ".zarr"
-        )
-
-        if s3.exists(s3_path.replace(".zarr", ".done")):
-            print("File already exists in S3, skipping download for: " + s3_path)
-            # If the file exists, check that it works
-            try:
-                hisCheckStore = zarr.storage.FsspecStore.from_url(
-                    s3_path,
-                    storage_options={
-                        "key": aws_access_key_id,
-                        "secret": aws_secret_access_key,
-                    },
-                )
-                zarr.open(hisCheckStore)[zarr_vars[-1]][-1, -1, -1]
-                continue  # If it exists, skip to the next iteration
-            except Exception:
-                print("### Historic Data Failure!")
-                print(traceback.print_exc())
-
-                # Delete the file if it exists
-                if s3.exists(s3_path):
-                    s3.rm(s3_path)
+        if s3.exists(done_file):
+            print(f"File already exists in S3, checking integrity for: {zarr_path}")
+            file_exists = True
     else:
-        # Local Path Setup
-        local_path = (
-            historic_path
-            + "/NBM_Fire_Hist"
-            + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")
-            + ".zarr"
-        )
+        if os.path.exists(done_file):
+            print(f"File already exists locally, checking integrity for: {zarr_path}")
+            file_exists = True
 
-        # Check for a loca done file
-        if os.path.exists(local_path.replace(".zarr", ".done")):
-            print("File already exists in S3, skipping download for: " + local_path)
+    if file_exists:
+        if check_historic_zarr(
+            zarr_path,
+            save_type,
+            zarr_vars,
+            aws_access_key_id,
+            aws_secret_access_key,
+        ):
+            print("Integrity check passed, skipping download for: " + zarr_path)
             continue
+        else:
+            print("Integrity check failed, file deleted. Redownloading for: " + zarr_path)
 
     print(
         "Downloading: " + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")

--- a/API/NBM_Fire_Local_Ingest.py
+++ b/API/NBM_Fire_Local_Ingest.py
@@ -8,7 +8,6 @@ import pickle
 import shutil
 import sys
 import time
-import traceback
 import warnings
 from datetime import datetime, timedelta
 
@@ -27,6 +26,7 @@ from API.ingest_utils import (
     CHUNK_SIZES,
     FINAL_CHUNK_SIZES,
     FORECAST_LEAD_RANGES,
+    check_historic_zarr,
     configure_zarr_limits,
     interp_time_take_blend,
     mask_invalid_data,
@@ -35,7 +35,6 @@ from API.ingest_utils import (
     run_command,
     tune_nofile_limit,
     validate_grib_stats,
-    check_historic_zarr,
 )
 
 
@@ -449,7 +448,7 @@ for i in range(his_period, 1, -6):
     done_file = zarr_path.replace(".zarr", ".done")
 
     file_exists = False
-    
+
     if save_type == "S3":
         if s3.exists(done_file):
             print(f"File already exists in S3, checking integrity for: {zarr_path}")
@@ -470,7 +469,9 @@ for i in range(his_period, 1, -6):
             print("Integrity check passed, skipping download for: " + zarr_path)
             continue
         else:
-            print("Integrity check failed, file deleted. Redownloading for: " + zarr_path)
+            print(
+                "Integrity check failed, file deleted. Redownloading for: " + zarr_path
+            )
 
     print(
         "Downloading: " + (base_time - pd.Timedelta(hours=i)).strftime("%Y%m%dT%H%M%SZ")

--- a/API/NBM_Local_Ingest.py
+++ b/API/NBM_Local_Ingest.py
@@ -39,6 +39,7 @@ from API.ingest_utils import (
     run_command,
     tune_nofile_limit,
     validate_grib_stats,
+    check_historic_zarr,
 )
 
 warnings.filterwarnings("ignore", "This pattern is interpreted")
@@ -925,40 +926,36 @@ for i in range(his_period, -1, -1):
     hist_iter_start = time.perf_counter()
     _timing_log(f"NBM_HIST {hist_target} start")
 
+    zarr_path = historic_path + "/NBM_Hist" + hist_target + ".zarr"
+    s3_path = zarr_path
+    local_path = zarr_path
+    done_file = zarr_path.replace(".zarr", ".done")
+
+    file_exists = False
+    
     if save_type == "S3":
-        s3_path = historic_path + "/NBM_Hist" + hist_target + ".zarr"
-        # Check for a done file in S3
-        if s3.exists(s3_path.replace(".zarr", ".done")):
-            print("File already exists in S3, skipping download for: " + s3_path)
+        if s3.exists(done_file):
+            print(f"File already exists in S3, checking integrity for: {zarr_path}")
             _timing_log(f"NBM_HIST {hist_target} skip (already exists)")
-
-            # If the file exists, check that it works
-            try:
-                hisCheckStore = zarr.storage.FsspecStore.from_url(
-                    s3_path,
-                    storage_options={
-                        "key": aws_access_key_id,
-                        "secret": aws_secret_access_key,
-                    },
-                )
-                zarr.open(hisCheckStore)[zarr_vars[-1]][-1, -1, -1]
-                continue  # If it exists, skip to the next iteration
-            except Exception:
-                print("### Historic Data Failure!")
-                print(traceback.print_exc())
-
-                # Delete the file if it exists
-                if s3.exists(s3_path):
-                    s3.rm(s3_path)
-
+            file_exists = True
     else:
-        # Local Path Setup
-        local_path = historic_path + "/NBM_Hist" + hist_target + ".zarr"
-        # Check for a loca done file
-        if os.path.exists(local_path.replace(".zarr", ".done")):
-            print("File already exists in S3, skipping download for: " + local_path)
+        if os.path.exists(done_file):
+            print(f"File already exists locally, checking integrity for: {zarr_path}")
             _timing_log(f"NBM_HIST {hist_target} skip (already exists)")
+            file_exists = True
+
+    if file_exists:
+        if check_historic_zarr(
+            zarr_path,
+            save_type,
+            zarr_vars,
+            aws_access_key_id,
+            aws_secret_access_key,
+        ):
+            print("Integrity check passed, skipping download for: " + zarr_path)
             continue
+        else:
+            print("Integrity check failed, file deleted. Redownloading for: " + zarr_path)
 
     print("Downloading: " + hist_target)
 

--- a/API/NBM_Local_Ingest.py
+++ b/API/NBM_Local_Ingest.py
@@ -9,7 +9,6 @@ import shutil
 import subprocess
 import sys
 import time
-import traceback
 import warnings
 from itertools import chain
 
@@ -30,6 +29,7 @@ from API.constants.shared_const import HISTORY_PERIODS, INGEST_VERSION_STR
 from API.ingest_utils import (
     CHUNK_SIZES,
     FINAL_CHUNK_SIZES,
+    check_historic_zarr,
     configure_zarr_limits,
     getGribList,
     interp_time_take_blend,
@@ -39,7 +39,6 @@ from API.ingest_utils import (
     run_command,
     tune_nofile_limit,
     validate_grib_stats,
-    check_historic_zarr,
 )
 
 warnings.filterwarnings("ignore", "This pattern is interpreted")
@@ -932,7 +931,7 @@ for i in range(his_period, -1, -1):
     done_file = zarr_path.replace(".zarr", ".done")
 
     file_exists = False
-    
+
     if save_type == "S3":
         if s3.exists(done_file):
             print(f"File already exists in S3, checking integrity for: {zarr_path}")
@@ -955,7 +954,9 @@ for i in range(his_period, -1, -1):
             print("Integrity check passed, skipping download for: " + zarr_path)
             continue
         else:
-            print("Integrity check failed, file deleted. Redownloading for: " + zarr_path)
+            print(
+                "Integrity check failed, file deleted. Redownloading for: " + zarr_path
+            )
 
     print("Downloading: " + hist_target)
 

--- a/API/constants/api_const.py
+++ b/API/constants/api_const.py
@@ -120,7 +120,7 @@ PRECIP_ACCUM_NOISE_THRESHOLD = (
 
 # API versioning and ingest version constants
 # Version scheme is: Major.Minor.Patch
-API_VERSION = "V2.9.3"
+API_VERSION = "V2.9.4a"
 
 # Generic API constants
 MAX_S3_RETRIES = 5

--- a/API/ingest_utils.py
+++ b/API/ingest_utils.py
@@ -628,3 +628,97 @@ def interpolate_temporal_gaps_efficiently(
 
     # Execute
     return ds_chunked.map(_process_variable)
+
+
+def check_historic_zarr(
+    zarr_path: str,
+    save_type: str,
+    expected_vars: tuple,
+    aws_access_key_id: str = "",
+    aws_secret_access_key: str = "",
+) -> bool:
+    """
+    Validates a historic Zarr store.
+
+    Checks that the store exists, can be opened, contains all expected variables,
+    and that data can be read from the last variable.
+    If the store is invalid, it is deleted along with any corresponding .done file.
+
+    Args:
+        zarr_path: Path to the Zarr store.
+        save_type: "S3" or "local" / "Download"
+        expected_vars: Tuple of expected variable names.
+        aws_access_key_id: AWS access key for S3.
+        aws_secret_access_key: AWS secret key for S3.
+
+    Returns:
+        True if the store is valid, False otherwise.
+    """
+    import os
+    import shutil
+    import traceback
+    import zarr
+
+    try:
+        if save_type == "S3":
+            import s3fs
+
+            s3 = s3fs.S3FileSystem(key=aws_access_key_id, secret=aws_secret_access_key)
+            if not s3.exists(zarr_path):
+                return False
+
+            store = zarr.storage.FsspecStore.from_url(
+                zarr_path,
+                storage_options={
+                    "key": aws_access_key_id,
+                    "secret": aws_secret_access_key,
+                },
+            )
+        else:
+            if not os.path.exists(zarr_path):
+                return False
+
+            store = zarr.storage.LocalStore(zarr_path)
+
+        # Open the zarr group.
+        z = zarr.open(store, mode="r")
+
+        # Check if all expected variables exist
+        store_vars = set(z.keys())
+        expected_set = set(expected_vars)
+        if not expected_set.issubset(store_vars):
+            print(f"Missing variables in {zarr_path}. Expected subset {expected_set}, found {store_vars}")
+            raise ValueError("Missing variables in Zarr store")
+
+        # Check the last variable has data by reading its last value
+        last_var = expected_vars[-1]
+        _ = z[last_var][-1, -1, -1]
+
+        return True
+
+    except Exception:
+        print(f"### Historic Data Failure for {zarr_path}!")
+        print(traceback.print_exc())
+
+        # Delete the invalid store
+        try:
+            if save_type == "S3":
+                import s3fs
+
+                s3 = s3fs.S3FileSystem(key=aws_access_key_id, secret=aws_secret_access_key)
+                if s3.exists(zarr_path):
+                    s3.rm(zarr_path, recursive=True)
+                done_file = zarr_path.replace(".zarr", ".done")
+                if s3.exists(done_file):
+                    s3.rm(done_file)
+            else:
+                if os.path.exists(zarr_path):
+                    shutil.rmtree(zarr_path, ignore_errors=True)
+                done_file = zarr_path.replace(".zarr", ".done")
+                if os.path.exists(done_file):
+                    os.remove(done_file)
+        except Exception as e:
+            print(f"Failed to delete corrupt store {zarr_path}: {e}")
+
+        return False
+

--- a/API/ingest_utils.py
+++ b/API/ingest_utils.py
@@ -657,6 +657,7 @@ def check_historic_zarr(
     import os
     import shutil
     import traceback
+
     import zarr
 
     try:
@@ -687,7 +688,9 @@ def check_historic_zarr(
         store_vars = set(z.keys())
         expected_set = set(expected_vars)
         if not expected_set.issubset(store_vars):
-            print(f"Missing variables in {zarr_path}. Expected subset {expected_set}, found {store_vars}")
+            print(
+                f"Missing variables in {zarr_path}. Expected subset {expected_set}, found {store_vars}"
+            )
             raise ValueError("Missing variables in Zarr store")
 
         # Check the last variable has data by reading its last value
@@ -705,7 +708,9 @@ def check_historic_zarr(
             if save_type == "S3":
                 import s3fs
 
-                s3 = s3fs.S3FileSystem(key=aws_access_key_id, secret=aws_secret_access_key)
+                s3 = s3fs.S3FileSystem(
+                    key=aws_access_key_id, secret=aws_secret_access_key
+                )
                 if s3.exists(zarr_path):
                     s3.rm(zarr_path, recursive=True)
                 done_file = zarr_path.replace(".zarr", ".done")
@@ -721,4 +726,3 @@ def check_historic_zarr(
             print(f"Failed to delete corrupt store {zarr_path}: {e}")
 
         return False
-

--- a/API/ingest_utils.py
+++ b/API/ingest_utils.py
@@ -307,7 +307,13 @@ def getGribList(FH_forecastsub, matchStrings):
                                 str(Path(x.get_localFilePath(matchStrings)).expand())
                                 for x in FH_forecastsub.file_exists
                             ]
-                        except (ValueError, OSError, KeyError, IndexError, RuntimeError):
+                        except (
+                            ValueError,
+                            OSError,
+                            KeyError,
+                            IndexError,
+                            RuntimeError,
+                        ):
                             print("Download Failure 6, Fail")
                             exit(1)
     return gribList

--- a/API/ingest_utils.py
+++ b/API/ingest_utils.py
@@ -124,7 +124,7 @@ def tune_nofile_limit(target: int = 65535) -> None:
         if new_soft > soft:
             resource.setrlimit(resource.RLIMIT_NOFILE, (new_soft, hard))
             print(f"Raised nofile soft limit from {soft} to {new_soft}")
-    except Exception as exc:
+    except (ValueError, OSError) as exc:
         print(f"Warning: unable to tune nofile limit: {exc}")
 
 
@@ -157,7 +157,7 @@ def configure_zarr_limits(
             async_cap = max(1, fd_budget // 512)
             workers = min(workers, worker_cap)
             async_concurrency = min(async_concurrency, async_cap)
-    except Exception as exc:
+    except (ValueError, OSError) as exc:
         print(f"Warning: unable to read nofile limit for zarr tuning: {exc}")
 
     async_concurrency = min(async_concurrency, workers)
@@ -262,7 +262,7 @@ def getGribList(FH_forecastsub, matchStrings):
             str(Path(x.get_localFilePath(matchStrings)).expand())
             for x in FH_forecastsub.file_exists
         ]
-    except Exception:
+    except (ValueError, OSError, KeyError, IndexError, RuntimeError):
         print("Download Failure 1, wait 20 seconds and retry")
         time.sleep(20)
         FH_forecastsub.download(matchStrings, verbose=False)
@@ -271,7 +271,7 @@ def getGribList(FH_forecastsub, matchStrings):
                 str(Path(x.get_localFilePath(matchStrings)).expand())
                 for x in FH_forecastsub.file_exists
             ]
-        except Exception:
+        except (ValueError, OSError, KeyError, IndexError, RuntimeError):
             print("Download Failure 2, wait 20 seconds and retry")
             time.sleep(20)
             FH_forecastsub.download(matchStrings, verbose=False)
@@ -280,7 +280,7 @@ def getGribList(FH_forecastsub, matchStrings):
                     str(Path(x.get_localFilePath(matchStrings)).expand())
                     for x in FH_forecastsub.file_exists
                 ]
-            except Exception:
+            except (ValueError, OSError, KeyError, IndexError, RuntimeError):
                 print("Download Failure 3, wait 20 seconds and retry")
                 time.sleep(20)
                 FH_forecastsub.download(matchStrings, verbose=False)
@@ -289,7 +289,7 @@ def getGribList(FH_forecastsub, matchStrings):
                         str(Path(x.get_localFilePath(matchStrings)).expand())
                         for x in FH_forecastsub.file_exists
                     ]
-                except Exception:
+                except (ValueError, OSError, KeyError, IndexError, RuntimeError):
                     print("Download Failure 4, wait 20 seconds and retry")
                     time.sleep(20)
                     FH_forecastsub.download(matchStrings, verbose=False)
@@ -298,7 +298,7 @@ def getGribList(FH_forecastsub, matchStrings):
                             str(Path(x.get_localFilePath(matchStrings)).expand())
                             for x in FH_forecastsub.file_exists
                         ]
-                    except Exception:
+                    except (ValueError, OSError, KeyError, IndexError, RuntimeError):
                         print("Download Failure 5, wait 20 seconds and retry")
                         time.sleep(20)
                         FH_forecastsub.download(matchStrings, verbose=False)
@@ -307,7 +307,7 @@ def getGribList(FH_forecastsub, matchStrings):
                                 str(Path(x.get_localFilePath(matchStrings)).expand())
                                 for x in FH_forecastsub.file_exists
                             ]
-                        except Exception:
+                        except (ValueError, OSError, KeyError, IndexError, RuntimeError):
                             print("Download Failure 6, Fail")
                             exit(1)
     return gribList
@@ -644,15 +644,15 @@ def check_historic_zarr(
     and that data can be read from the last variable.
     If the store is invalid, it is deleted along with any corresponding .done file.
 
-    Args:
-        zarr_path: Path to the Zarr store.
-        save_type: "S3" or "local" / "Download"
-        expected_vars: Tuple of expected variable names.
-        aws_access_key_id: AWS access key for S3.
-        aws_secret_access_key: AWS secret key for S3.
+    Parameters:
+    - zarr_path (str): Path to the Zarr store.
+    - save_type (str): "S3" or "local" / "Download"
+    - expected_vars (tuple): Tuple of expected variable names.
+    - aws_access_key_id (str): AWS access key for S3.
+    - aws_secret_access_key (str): AWS secret key for S3.
 
     Returns:
-        True if the store is valid, False otherwise.
+    - bool: True if the store is valid, False otherwise.
     """
     import os
     import shutil
@@ -660,6 +660,7 @@ def check_historic_zarr(
 
     import zarr
 
+    s3 = None
     try:
         if save_type == "S3":
             import s3fs
@@ -699,30 +700,33 @@ def check_historic_zarr(
 
         return True
 
-    except Exception:
+    except (
+        ValueError,
+        IndexError,
+        KeyError,
+        zarr.errors.GroupNotFoundError,
+        zarr.errors.PathNotFoundError,
+        zarr.errors.ArrayNotFoundError,
+    ):
         print(f"### Historic Data Failure for {zarr_path}!")
         print(traceback.print_exc())
 
         # Delete the invalid store
         try:
             if save_type == "S3":
-                import s3fs
-
-                s3 = s3fs.S3FileSystem(
-                    key=aws_access_key_id, secret=aws_secret_access_key
-                )
-                if s3.exists(zarr_path):
-                    s3.rm(zarr_path, recursive=True)
-                done_file = zarr_path.replace(".zarr", ".done")
-                if s3.exists(done_file):
-                    s3.rm(done_file)
+                if s3 is not None:
+                    if s3.exists(zarr_path):
+                        s3.rm(zarr_path, recursive=True)
+                    done_file = zarr_path.replace(".zarr", ".done")
+                    if s3.exists(done_file):
+                        s3.rm(done_file)
             else:
                 if os.path.exists(zarr_path):
                     shutil.rmtree(zarr_path, ignore_errors=True)
                 done_file = zarr_path.replace(".zarr", ".done")
                 if os.path.exists(done_file):
                     os.remove(done_file)
-        except Exception as e:
+        except OSError as e:
             print(f"Failed to delete corrupt store {zarr_path}: {e}")
 
         return False

--- a/tests/test_compare_production.py
+++ b/tests/test_compare_production.py
@@ -17,6 +17,8 @@ PROD_TIMEMACHINE_BASE = "https://api.pirateweather.net/timemachine"
 TIMEMACHINE_TEST_LOCATION = (45.4215, -75.6972)  # Ottawa, Canada
 TIMEMACHINE_TEST_DATE = datetime.datetime(2020, 6, 15, tzinfo=datetime.UTC)
 TIMEMACHINE_TIMESTAMP = int(TIMEMACHINE_TEST_DATE.timestamp())
+TIMEMACHINE_DST_TEST_LOCATION = (45.0, -75.0)  # Near Ottawa, DST boundary case
+TIMEMACHINE_DST_TIMESTAMP = 1741463176  # 2025-03-08 19:46:16 UTC
 
 
 class ProductionRequestError(Exception):
@@ -169,5 +171,34 @@ def test_timemachine_vs_production():
         diff_text = json.dumps(diffs, indent=2, sort_keys=True)
         warnings.warn(
             f"Timemachine differences for {lat},{lon} at {timestamp}:\n{diff_text}",
+            DiffWarning,
+        )
+
+
+@pytest.mark.skipif(
+    not PW_API,
+    reason="PW_API environment variable not set",
+)
+def test_timemachine_dst_vs_production():
+    client = _get_client()
+
+    lat, lon = TIMEMACHINE_DST_TEST_LOCATION
+    timestamp = TIMEMACHINE_DST_TIMESTAMP
+
+    local_resp = client.get(f"/timemachine/{PW_API}/{lat},{lon},{timestamp}?version=2")
+    assert local_resp.status_code == 200
+    local_data = local_resp.json()
+
+    prod_url = f"{PROD_TIMEMACHINE_BASE}/{PW_API}/{lat},{lon},{timestamp}?version=2"
+    try:
+        prod_data = _fetch_production_json(prod_url)
+    except ProductionRequestError as exc:  # pragma: no cover - network failure
+        pytest.skip(f"Could not fetch production API: {exc}")
+
+    diffs = _diff_nested(local_data, prod_data)
+    if diffs:
+        diff_text = json.dumps(diffs, indent=2, sort_keys=True)
+        warnings.warn(
+            f"Timemachine DST differences for {lat},{lon} at {timestamp}:\n{diff_text}",
             DiffWarning,
         )


### PR DESCRIPTION
## Describe the change
Found that using reflectivity for entire atmosphere causes the summary to show rain when it isn't actually raining so change to 1km reflectivity for better results.

@alexander0042 This shouldn't break anything correct?

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes https://github.com/Pirate-Weather/pirateweather/issues/599
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [ ] The TimeMachine version (in API/timemachine.py) matches the API version number
