### PR TITLE
Prioritize HRRR CAPE over NBM CAPE for the currently block

### DIFF
--- a/API/constants/api_const.py
+++ b/API/constants/api_const.py
@@ -120,7 +120,7 @@ PRECIP_ACCUM_NOISE_THRESHOLD = (
 
 # API versioning and ingest version constants
 # Version scheme is: Major.Minor.Patch
-API_VERSION = "V2.9.4a"
+API_VERSION = "V2.9.4b"
 
 # Generic API constants
 MAX_S3_RETRIES = 5

--- a/API/current/metrics.py
+++ b/API/current/metrics.py
@@ -1137,13 +1137,13 @@ def _get_cape(sourceList, model_data, state: InterpolationState, lat, lon):
         Current CAPE.
     """
     source_map = {
-        "nbm": (
-            lambda: "nbm" in sourceList,
-            lambda: _interp_scalar(model_data["NBM_Merged"], NBM["cape"], state),
-        ),
         "hrrr": (
             lambda: model_data["has_hrrr_merged"],
             lambda: _interp_scalar(model_data["HRRR_Merged"], HRRR["cape"], state),
+        ),
+        "nbm": (
+            lambda: "nbm" in sourceList,
+            lambda: _interp_scalar(model_data["NBM_Merged"], NBM["cape"], state),
         ),
         "gfs": (
             lambda: "gfs" in sourceList,


### PR DESCRIPTION
## Describe the change
Noticed that the currently block was using NBM CAPE over HRRR so I swapped the priority which should give better results for the currently block.

For example:

Alexandria, Louisiana has a current CAPE of 2709 with HRRR vs 1536 for NBM and from what I can tell HRRR seems more accurate vs NBM for the current time.

### AI Disclosure
While I did not use AI to make this change I did use it to help find where the change should be made and did a brief discussion about whether HRRR CAPE is better for the currently block.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates
- [x] I was assisted by AI

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [ ] The TimeMachine version (in API/timemachine.py) matches the API version number
