### PR TITLE
Add priority to ECMWF Herbie functions

### DIFF
--- a/API/ECMWF_AIFS_Local_Ingest.py
+++ b/API/ECMWF_AIFS_Local_Ingest.py
@@ -186,6 +186,7 @@ FH_forecastsub = FastHerbie(
     fxx=aifs_range,
     product="enfo",
     verbose=True,
+    priority=["aws", "ecmwf"],
     save_dir=tmp_dir,
 )
 
@@ -510,6 +511,7 @@ for i in range(his_period, -1, -6):
         fxx=fxx,
         product="enfo",
         verbose=True,
+        priority=["aws", "ecmwf"],
         save_dir=tmp_dir,
     )
 
@@ -586,7 +588,7 @@ for i in range(his_period, -1, -6):
     ## Deterministic
     # Create FastHerbie Object.
     FH_histsub = FastHerbie(
-        DATES, model="aifs", fxx=fxx, product="oper", verbose=False, save_dir=tmp_dir
+        DATES, model="aifs", fxx=fxx, product="oper", verbose=False, priority=["aws", "ecmwf"], save_dir=tmp_dir
     )
 
     # Download the subsets

--- a/API/ECMWF_AIFS_Local_Ingest.py
+++ b/API/ECMWF_AIFS_Local_Ingest.py
@@ -588,7 +588,13 @@ for i in range(his_period, -1, -6):
     ## Deterministic
     # Create FastHerbie Object.
     FH_histsub = FastHerbie(
-        DATES, model="aifs", fxx=fxx, product="oper", verbose=False, priority=["aws", "ecmwf"], save_dir=tmp_dir
+        DATES,
+        model="aifs",
+        fxx=fxx,
+        product="oper",
+        verbose=False,
+        priority=["aws", "ecmwf"],
+        save_dir=tmp_dir,
     )
 
     # Download the subsets

--- a/API/ECMWF_Local_Ingest.py
+++ b/API/ECMWF_Local_Ingest.py
@@ -188,6 +188,7 @@ FH_forecastsub = FastHerbie(
     fxx=ifsFileRange,
     product="enfo",
     verbose=False,
+    priority=["aws", "ecmwf"],
     save_dir=tmp_dir,
 )
 
@@ -499,7 +500,7 @@ for i in range(his_period, 1, -12):
 
     # Create FastHerbie Object.
     FH_histsub = FastHerbie(
-        DATES, model="ifs", fxx=fxx, product="oper", verbose=False, save_dir=tmp_dir
+        DATES, model="ifs", fxx=fxx, product="oper", verbose=False, priority=["aws", "ecmwf"], save_dir=tmp_dir
     )
 
     # Download the subsets
@@ -603,7 +604,7 @@ for i in range(his_period, 1, -12):
     ### Download the enfo data
     # Create FastHerbie Object.
     FH_histsub = FastHerbie(
-        DATES, model="ifs", fxx=fxx, product="enfo", verbose=False, save_dir=tmp_dir
+        DATES, model="ifs", fxx=fxx, product="enfo", verbose=False, priority=["aws", "ecmwf"], save_dir=tmp_dir
     )
 
     ens_his_paths = FH_histsub.download(match_string_enfo, verbose=False)

--- a/API/ECMWF_Local_Ingest.py
+++ b/API/ECMWF_Local_Ingest.py
@@ -500,7 +500,13 @@ for i in range(his_period, 1, -12):
 
     # Create FastHerbie Object.
     FH_histsub = FastHerbie(
-        DATES, model="ifs", fxx=fxx, product="oper", verbose=False, priority=["aws", "ecmwf"], save_dir=tmp_dir
+        DATES,
+        model="ifs",
+        fxx=fxx,
+        product="oper",
+        verbose=False,
+        priority=["aws", "ecmwf"],
+        save_dir=tmp_dir,
     )
 
     # Download the subsets
@@ -604,7 +610,13 @@ for i in range(his_period, 1, -12):
     ### Download the enfo data
     # Create FastHerbie Object.
     FH_histsub = FastHerbie(
-        DATES, model="ifs", fxx=fxx, product="enfo", verbose=False, priority=["aws", "ecmwf"], save_dir=tmp_dir
+        DATES,
+        model="ifs",
+        fxx=fxx,
+        product="enfo",
+        verbose=False,
+        priority=["aws", "ecmwf"],
+        save_dir=tmp_dir,
     )
 
     ens_his_paths = FH_histsub.download(match_string_enfo, verbose=False)


### PR DESCRIPTION
## Describe the change
Made sure that all Herbie functions have AWS and ECMWF as priority to hopefully fix ingest issues. Some of the Herbie functions didn't have priority so was probably using the default.

Didn't add Azure as an option since I think it's not public like it is for AWS.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [ ] The TimeMachine version (in API/timemachine.py) matches the API version number
