### PR TITLE
Revert ECMWF cloud API fix

### DIFF
--- a/API/current/metrics.py
+++ b/API/current/metrics.py
@@ -99,7 +99,6 @@ _CURRENTLY_ORDER_NA = [
     "hrrrsubh",
     "nbm",
     "hrrr",
-    "ecmwf_aifs",
     "ecmwf_ifs",
     "gfs",
     "dwd_mosmix",
@@ -111,7 +110,6 @@ _CURRENTLY_ORDER_ROW = [
     "nbm",
     "hrrr",
     "dwd_mosmix",
-    "ecmwf_aifs",
     "ecmwf_ifs",
     "gfs",
     "era5",
@@ -123,13 +121,11 @@ _CURRENTLY_ORDER_AI_NA = [
     "hrrr",
     "gfs",
     "gefs",
-    "ecmwf_aifs",
     "ecmwf_ifs",
     "dwd_mosmix",
     "era5",
 ]
 _CURRENTLY_ORDER_AI_ROW = [
-    "ecmwf_aifs",
     "ecmwf_ifs",
     "rtma_ru",
     "hrrrsubh",
@@ -337,10 +333,6 @@ def _get_temp(
                 model_data["DWD_MOSMIX_Merged"], DWD_MOSMIX["temp"], state
             ),
         ),
-        "ecmwf_aifs": (
-            lambda: "ecmwf_aifs" in sourceList,
-            lambda: _interp_scalar(model_data["ECMWF_Merged"], ECMWF["temp"], state),
-        ),
         "ecmwf_ifs": (
             lambda: "ecmwf_ifs" in sourceList,
             lambda: _interp_scalar(model_data["ECMWF_Merged"], ECMWF["temp"], state),
@@ -406,10 +398,6 @@ def _get_dew(
             lambda: _interp_scalar(
                 model_data["DWD_MOSMIX_Merged"], DWD_MOSMIX["dew"], state
             ),
-        ),
-        "ecmwf_aifs": (
-            lambda: "ecmwf_aifs" in sourceList,
-            lambda: _interp_scalar(model_data["ECMWF_Merged"], ECMWF["dew"], state),
         ),
         "ecmwf_ifs": (
             lambda: "ecmwf_ifs" in sourceList,
@@ -494,12 +482,6 @@ def _get_humidity(
                 * humidUnit
             ),
         ),
-        "ecmwf_aifs": (
-            lambda: "ecmwf_aifs" in sourceList,
-            lambda: _calculate_ecmwf_relative_humidity(
-                model_data["ECMWF_Merged"], state, humidUnit
-            ),
-        ),
         "ecmwf_ifs": (
             lambda: "ecmwf_ifs" in sourceList,
             lambda: _calculate_ecmwf_relative_humidity(
@@ -553,12 +535,6 @@ def _get_pressure(
             lambda: "dwd_mosmix" in sourceList,
             lambda: _interp_scalar(
                 model_data["DWD_MOSMIX_Merged"], DWD_MOSMIX["pressure"], state
-            ),
-        ),
-        "ecmwf_aifs": (
-            lambda: "ecmwf_aifs" in sourceList,
-            lambda: _interp_scalar(
-                model_data["ECMWF_Merged"], ECMWF["pressure"], state
             ),
         ),
         "ecmwf_ifs": (
@@ -634,15 +610,6 @@ def _get_wind(
                 model_data["DWD_MOSMIX_Merged"],
                 DWD_MOSMIX["wind_u"],
                 DWD_MOSMIX["wind_v"],
-                state,
-            ),
-        ),
-        "ecmwf_aifs": (
-            lambda: "ecmwf_aifs" in sourceList,
-            lambda: _interp_uv_magnitude(
-                model_data["ECMWF_Merged"],
-                ECMWF["wind_u"],
-                ECMWF["wind_v"],
                 state,
             ),
         ),
@@ -881,13 +848,6 @@ def _get_bearing(
                 model_data["DWD_MOSMIX_Merged"][state.idx2, DWD_MOSMIX["wind_v"]],
             ),
         ),
-        "ecmwf_aifs": (
-            lambda: "ecmwf_aifs" in sourceList,
-            lambda: _bearing_from_components(
-                model_data["ECMWF_Merged"][state.idx2, ECMWF["wind_u"]],
-                model_data["ECMWF_Merged"][state.idx2, ECMWF["wind_v"]],
-            ),
-        ),
         "ecmwf_ifs": (
             lambda: "ecmwf_ifs" in sourceList,
             lambda: _bearing_from_components(
@@ -960,15 +920,11 @@ def _get_cloud(
                 * 0.01
             ),
         ),
-        "ecmwf_aifs": (
-            lambda: "ecmwf_aifs" in sourceList,
+        "ecmwf_ifs": (
+            lambda: "ecmwf_ifs" in sourceList,
             lambda: (
                 _interp_scalar(model_data["ECMWF_Merged"], ECMWF["cloud"], state) * 0.01
             ),
-        ),
-        "ecmwf_ifs": (
-            lambda: "ecmwf_ifs" in sourceList,
-            lambda: _interp_scalar(model_data["ECMWF_Merged"], ECMWF["cloud"], state),
         ),
         "hrrr": (
             lambda: model_data["has_hrrr_merged"],

--- a/API/data_inputs.py
+++ b/API/data_inputs.py
@@ -660,21 +660,11 @@ def prepare_data_inputs(
     )
 
     # --- cloud_inputs ---
-    ecmwf_cloud = None
-
-    # Normalize ECMWF cloud cover to the 0-1 range for consistency with other sources.
-    # When the ECMWF source is AIFS, cloud cover is provided in the 0-100% range and must be converted.
-    # Other ECMWF cloud values are already expected to be in the 0-1 range and are used directly.
-    if ecmwf_merged is not None:
-        if "ecmwf_aifs" in source_list:
-            ecmwf_cloud = ecmwf_merged[:, ECMWF["cloud"]] * 0.01
-        else:
-            ecmwf_cloud = ecmwf_merged[:, ECMWF["cloud"]]
-
     cloud_inputs = _stack_with_priority(
         num_hours,
         lat,
         lon,
+        has_ecmwf=True,  # ECMWF has data
         source_data={
             "nbm": nbm_merged[:, NBM["cloud"]] * 0.01
             if nbm_merged is not None
@@ -685,7 +675,9 @@ def prepare_data_inputs(
             "dwd_mosmix": dwd_mosmix_merged[:, DWD_MOSMIX["cloud"]] * 0.01
             if dwd_valid
             else None,
-            "ecmwf": ecmwf_cloud,
+            "ecmwf": ecmwf_merged[:, ECMWF["cloud"]] * 0.01
+            if ecmwf_merged is not None
+            else None,
             "gfs": gfs_merged[:, GFS["cloud"]] * 0.01
             if gfs_merged is not None
             else None,

--- a/API/data_inputs.py
+++ b/API/data_inputs.py
@@ -664,7 +664,6 @@ def prepare_data_inputs(
         num_hours,
         lat,
         lon,
-        has_ecmwf=True,  # ECMWF has data
         source_data={
             "nbm": nbm_merged[:, NBM["cloud"]] * 0.01
             if nbm_merged is not None


### PR DESCRIPTION
## Describe the change
For some reason the Python 3.14 PR didn't contain the reverted code for the data inputs/currently metrics. Since its fixed on ingest we don't need this anymore (and will cause issues with the updated ingest)

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [ ] The TimeMachine version (in API/timemachine.py) matches the API version number
