### PR TITLE
Add a variable check to ingest extraction script

### DIFF
--- a/.github/workflows/rtma-ingest-test.yml
+++ b/.github/workflows/rtma-ingest-test.yml
@@ -30,3 +30,5 @@ jobs:
         run: pytest -v tests/test_dwd_interp_flow.py
       - name: Run DWD NaN Interp test
         run: pytest -v tests/test_interpolate_nan_along_axis.py
+      - name: Run historic archive extract test
+        run: pytest -v tests/test_historic_archive_extract.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Run pytest
         env:
           PW_API: ${{ secrets.PW_API }}
-        run: pytest -q --ignore=tests/test_rtma_ingest.py --ignore=tests/test_hrrr_6h_ingest.py --ignore=tests/test_dwd_interp_flow.py --ignore=tests/test_interpolate_nan_along_axis.py
+        run: pytest -q --ignore=tests/test_rtma_ingest.py --ignore=tests/test_hrrr_6h_ingest.py --ignore=tests/test_dwd_interp_flow.py --ignore=tests/test_interpolate_nan_along_axis.py --ignore=tests/test_historic_archive_extract.py

--- a/API/AIGEFS_Local_Ingest.py
+++ b/API/AIGEFS_Local_Ingest.py
@@ -649,7 +649,7 @@ if save_type == "S3":
             final_zarr_name=final_zarr_name,
             extracted_store_name="AIGEFS_HistProb.zarr",
             local_temp_dir=local_temp_dir,
-            expected_vars=zarr_vars,
+            expected_vars=probVars,
         )
         if extracted_path is not None:
             ncLocalWorking_paths.append(extracted_path)

--- a/API/AIGEFS_Local_Ingest.py
+++ b/API/AIGEFS_Local_Ingest.py
@@ -649,6 +649,7 @@ if save_type == "S3":
             final_zarr_name=final_zarr_name,
             extracted_store_name="AIGEFS_HistProb.zarr",
             local_temp_dir=local_temp_dir,
+            expected_vars=zarr_vars,
         )
         if extracted_path is not None:
             ncLocalWorking_paths.append(extracted_path)

--- a/API/AIGFS_Local_Ingest.py
+++ b/API/AIGFS_Local_Ingest.py
@@ -473,6 +473,7 @@ if save_type == "S3":
             final_zarr_name=final_zarr_name,
             extracted_store_name="AIGFS_Hist.zarr",
             local_temp_dir=local_temp_dir,
+            expected_vars=zarr_vars,
         )
         if extracted_path is not None:
             ncLocalWorking_paths.append(extracted_path)

--- a/API/ECMWF_AIFS_Local_Ingest.py
+++ b/API/ECMWF_AIFS_Local_Ingest.py
@@ -765,6 +765,7 @@ if save_type == "S3":
             final_zarr_name=final_zarr_name,
             extracted_store_name="ECMWF_AIFS_Hist.zarr",
             local_temp_dir=local_temp_dir,
+            expected_vars=zarr_vars,
         )
         if extracted_path is not None:
             ncLocalWorking_paths.append(extracted_path)

--- a/API/ECMWF_Local_Ingest.py
+++ b/API/ECMWF_Local_Ingest.py
@@ -737,6 +737,7 @@ if save_type == "S3":
             final_zarr_name=final_zarr_name,
             extracted_store_name="ECMWF_Hist.zarr",
             local_temp_dir=local_temp_dir,
+            expected_vars=zarr_vars,
         )
         if extracted_path is not None:
             ncLocalWorking_paths.append(extracted_path)

--- a/API/GEFS_Local_Ingest.py
+++ b/API/GEFS_Local_Ingest.py
@@ -670,6 +670,7 @@ if save_type == "S3":
             final_zarr_name=final_zarr_name,
             extracted_store_name="GEFS_Hist.zarr",
             local_temp_dir=local_temp_dir,
+            expected_vars=zarr_vars,
         )
         if extracted_path is not None:
             ncLocalWorking_paths.append(extracted_path)

--- a/API/GEFS_Local_Ingest.py
+++ b/API/GEFS_Local_Ingest.py
@@ -670,7 +670,7 @@ if save_type == "S3":
             final_zarr_name=final_zarr_name,
             extracted_store_name="GEFS_Hist.zarr",
             local_temp_dir=local_temp_dir,
-            expected_vars=zarr_vars,
+            expected_vars=probVars,
         )
         if extracted_path is not None:
             ncLocalWorking_paths.append(extracted_path)

--- a/API/GFS_Local_Ingest.py
+++ b/API/GFS_Local_Ingest.py
@@ -918,6 +918,7 @@ if save_type == "S3":
             final_zarr_name=final_zarr_name,
             extracted_store_name="GFS_Hist.zarr",
             local_temp_dir=local_temp_dir,
+            expected_vars=zarr_vars,
         )
         if extracted_path is None:
             tqdm.write(f"Error: GFS_Hist.zarr not found inside archive for {timestamp}")

--- a/API/HRRR_Local_Ingest.py
+++ b/API/HRRR_Local_Ingest.py
@@ -536,6 +536,7 @@ if save_type == "S3":
             final_zarr_name=final_zarr_name,
             extracted_store_name="HRRR_Hist.zarr",
             local_temp_dir=local_temp_dir,
+            expected_vars=zarr_vars,
         )
         if extracted_path is not None:
             ncHistWorking_paths.append(extracted_path)

--- a/API/NBM_Fire_Local_Ingest.py
+++ b/API/NBM_Fire_Local_Ingest.py
@@ -594,6 +594,7 @@ if save_type == "S3":
             final_zarr_name=final_zarr_name,
             extracted_store_name="NBM_Fire_Hist.zarr",
             local_temp_dir=local_temp_dir,
+            expected_vars=zarr_vars,
         )
         if extracted_path is not None:
             ncLocalWorking_paths.append(extracted_path)

--- a/API/NBM_Local_Ingest.py
+++ b/API/NBM_Local_Ingest.py
@@ -1137,6 +1137,7 @@ if save_type == "S3":
             final_zarr_name=final_zarr_name,
             extracted_store_name="NBM_Hist.zarr",
             local_temp_dir=local_temp_dir,
+            expected_vars=zarr_vars,
         )
         if extracted_path is not None:
             ncLocalWorking_paths.append(extracted_path)

--- a/API/ingest_utils.py
+++ b/API/ingest_utils.py
@@ -12,6 +12,7 @@ import tarfile
 import time
 from typing import Iterable, Optional, Union
 
+import cartopy.crs as ccrs
 import dask.array as da
 import numpy as np
 import xarray as xr
@@ -547,8 +548,6 @@ def earth_relative_wind_components(
         A tuple containing two numpy arrays: the earth-relative u-component (ut)
         and v-component (vt) of the wind.
     """
-    import cartopy.crs as ccrs
-
     data_crs = ugrd.metpy_crs.metpy.cartopy_crs
 
     x = ugrd.x.values

--- a/API/ingest_utils.py
+++ b/API/ingest_utils.py
@@ -261,6 +261,39 @@ def archive_tmp_zarr_and_upload(
     s3.touch(s3_path.replace(".tar.gz", ".done"))
 
 
+def _delete_historic_archive_from_s3(s3, s3_tar_path: str) -> None:
+    """Delete a historic zarr archive and its completion marker from S3."""
+    s3_zarr_path = s3_tar_path.removesuffix(".tar.gz")
+    for path in (
+        s3_tar_path,
+        s3_zarr_path,
+        s3_tar_path.replace(".tar.gz", ".done"),
+    ):
+        if s3.exists(path):
+            s3.rm(path, recursive=True)
+
+
+def _validate_historic_zarr_variables(
+    zarr_path: str,
+    expected_vars: Iterable[str] | None,
+) -> None:
+    """Validate that a local historic zarr contains every expected variable."""
+    if expected_vars is None:
+        return
+
+    import zarr
+
+    z = zarr.open(zarr_path, mode="r")
+    store_vars = set(z.keys())
+    expected_set = set(expected_vars)
+    missing_vars = sorted(expected_set - store_vars)
+    if missing_vars:
+        raise ValueError(
+            f"Missing variables in extracted historic zarr {zarr_path}: "
+            f"{missing_vars}. Found variables: {sorted(store_vars)}"
+        )
+
+
 def download_extract_historic_archive(
     *,
     s3,
@@ -268,15 +301,24 @@ def download_extract_historic_archive(
     final_zarr_name: str,
     extracted_store_name: str,
     local_temp_dir: str,
+    expected_vars: Iterable[str] | None = None,
 ) -> Optional[str]:
     """Helper to download and extract a historic archive to a local zarr path."""
     os.makedirs(local_temp_dir, exist_ok=True)
     local_zarr_path = os.path.join(local_temp_dir, final_zarr_name)
-    if os.path.exists(local_zarr_path):
-        return local_zarr_path
 
     tar_name = f"{final_zarr_name}.tar.gz"
     s3_tar_path = f"{historic_path}/{tar_name}"
+
+    if os.path.exists(local_zarr_path):
+        try:
+            _validate_historic_zarr_variables(local_zarr_path, expected_vars)
+        except Exception:
+            shutil.rmtree(local_zarr_path, ignore_errors=True)
+            _delete_historic_archive_from_s3(s3, s3_tar_path)
+            raise
+        return local_zarr_path
+
     if not s3.exists(s3_tar_path):
         return None
 
@@ -284,18 +326,27 @@ def download_extract_historic_archive(
     timestamp_tag = final_zarr_name.replace(".zarr", "")
     extract_dir = os.path.join(local_temp_dir, f"extract_{timestamp_tag}")
 
-    s3.get_file(s3_tar_path, local_tar_path)
-    os.makedirs(extract_dir, exist_ok=True)
-    with tarfile.open(local_tar_path, "r:gz") as tar:
-        tar.extractall(path=extract_dir, filter="data")
+    try:
+        s3.get_file(s3_tar_path, local_tar_path)
+        os.makedirs(extract_dir, exist_ok=True)
+        with tarfile.open(local_tar_path, "r:gz") as tar:
+            tar.extractall(path=extract_dir, filter="data")
 
-    extracted_source = os.path.join(extract_dir, extracted_store_name)
-    if os.path.exists(extracted_source):
-        shutil.move(extracted_source, local_zarr_path)
+        extracted_source = os.path.join(extract_dir, extracted_store_name)
+        if os.path.exists(extracted_source):
+            shutil.move(extracted_source, local_zarr_path)
 
-    if os.path.exists(local_tar_path):
-        os.remove(local_tar_path)
-    shutil.rmtree(extract_dir, ignore_errors=True)
+        if os.path.exists(local_zarr_path):
+            _validate_historic_zarr_variables(local_zarr_path, expected_vars)
+    except Exception:
+        shutil.rmtree(local_zarr_path, ignore_errors=True)
+        _delete_historic_archive_from_s3(s3, s3_tar_path)
+        raise
+    finally:
+        if os.path.exists(local_tar_path):
+            os.remove(local_tar_path)
+        shutil.rmtree(extract_dir, ignore_errors=True)
+
     return local_zarr_path if os.path.exists(local_zarr_path) else None
 
 

--- a/API/ingest_utils.py
+++ b/API/ingest_utils.py
@@ -12,7 +12,6 @@ import tarfile
 import time
 from typing import Iterable, Optional, Union
 
-import cartopy.crs as ccrs
 import dask.array as da
 import numpy as np
 import xarray as xr
@@ -548,6 +547,8 @@ def earth_relative_wind_components(
         A tuple containing two numpy arrays: the earth-relative u-component (ut)
         and v-component (vt) of the wind.
     """
+    import cartopy.crs as ccrs
+
     data_crs = ugrd.metpy_crs.metpy.cartopy_crs
 
     x = ugrd.x.values

--- a/tests/test_historic_archive_extract.py
+++ b/tests/test_historic_archive_extract.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import pytest
 import zarr
 
+pytest.importorskip("herbie")
+
 from API.ingest_utils import download_extract_historic_archive
 
 

--- a/tests/test_historic_archive_extract.py
+++ b/tests/test_historic_archive_extract.py
@@ -1,0 +1,98 @@
+import shutil
+import tarfile
+from pathlib import Path
+
+import pytest
+import zarr
+
+from API.ingest_utils import download_extract_historic_archive
+
+
+class FakeS3:
+    def exists(self, path):
+        return Path(path).exists()
+
+    def get_file(self, src, dst):
+        shutil.copyfile(src, dst)
+
+    def rm(self, path, recursive=False):
+        target = Path(path)
+        if target.is_dir():
+            shutil.rmtree(target)
+        elif target.exists():
+            target.unlink()
+
+
+def _write_zarr(path, variables):
+    root = zarr.open_group(str(path), mode="w")
+    for variable in variables:
+        arr = root.create_array(
+            variable, shape=(1, 1, 1), chunks=(1, 1, 1), dtype="float32"
+        )
+        arr[:] = 1
+
+
+def _write_archive(historic_path, final_zarr_name, member_name, variables):
+    source_zarr = historic_path / member_name
+    _write_zarr(source_zarr, variables)
+
+    archive_path = historic_path / f"{final_zarr_name}.tar.gz"
+    with tarfile.open(archive_path, "w:gz") as archive:
+        archive.add(source_zarr, arcname=member_name)
+
+    shutil.rmtree(source_zarr)
+    done_path = historic_path / f"{final_zarr_name}.done"
+    done_path.touch()
+    return archive_path, done_path
+
+
+def test_download_extract_historic_archive_validates_expected_vars(tmp_path):
+    historic_path = tmp_path / "historic"
+    historic_path.mkdir()
+    local_temp_dir = tmp_path / "downloads"
+    final_zarr_name = "Model_Hist_v320260528T000000Z.zarr"
+    _write_archive(
+        historic_path,
+        final_zarr_name,
+        "Model_Hist.zarr",
+        ("time", "TMP_2maboveground"),
+    )
+
+    extracted_path = download_extract_historic_archive(
+        s3=FakeS3(),
+        historic_path=str(historic_path),
+        final_zarr_name=final_zarr_name,
+        extracted_store_name="Model_Hist.zarr",
+        local_temp_dir=str(local_temp_dir),
+        expected_vars=("time", "TMP_2maboveground"),
+    )
+
+    assert extracted_path == str(local_temp_dir / final_zarr_name)
+    assert Path(extracted_path).exists()
+
+
+def test_download_extract_historic_archive_deletes_s3_archive_on_missing_vars(tmp_path):
+    historic_path = tmp_path / "historic"
+    historic_path.mkdir()
+    local_temp_dir = tmp_path / "downloads"
+    final_zarr_name = "Model_Hist_v320260528T000000Z.zarr"
+    archive_path, done_path = _write_archive(
+        historic_path,
+        final_zarr_name,
+        "Model_Hist.zarr",
+        ("time",),
+    )
+
+    with pytest.raises(ValueError, match="Missing variables"):
+        download_extract_historic_archive(
+            s3=FakeS3(),
+            historic_path=str(historic_path),
+            final_zarr_name=final_zarr_name,
+            extracted_store_name="Model_Hist.zarr",
+            local_temp_dir=str(local_temp_dir),
+            expected_vars=("time", "TMP_2maboveground"),
+        )
+
+    assert not archive_path.exists()
+    assert not done_path.exists()
+    assert not (local_temp_dir / final_zarr_name).exists()


### PR DESCRIPTION
## Describe the change
Add a check that all the variables are in the compressed zarr files. If not, delete the files and exit the script as a failure, allowing it to retry the download.

Re: <https://github.com/Pirate-Weather/pirateweather/issues/625#issuecomment-4564326414>


## Type of change

- [X] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [X] Code builds locally. **Your pull request won't be merged unless tests pass**
- [X] Code has been formatted using ruff
- [X] The TimeMachine version (in API/timemachine.py) matches the API version number
