### PR TITLE
Change sub-hourly HRRR reflectivity to match other HRRR products

### DIFF
--- a/API/SubH_Local_Ingest.py
+++ b/API/SubH_Local_Ingest.py
@@ -150,7 +150,7 @@ zarr_vars = (
     "CICEP_surface",
     "CFRZR_surface",
     "CRAIN_surface",
-    "REFC_entireatmosphere",
+    "REFD_1000maboveground",
     "APCP_surface",
     "VIS_surface",
     "SPFH_2maboveground",
@@ -171,7 +171,7 @@ matchstring_su = (
     ":((CRAIN|CICEP|CSNOW|CFRZR|PRES|PRATE|VIS|GUST|DSWRF):surface:.*min fcst)"
 )
 matchstring_10m = "(:(UGRD|VGRD):10 m above ground:.*min fcst)"
-matchstring_sl = "(:(REFC):)"
+matchstring_1000m = "(:REFD:1000 m above ground:)"
 matchstring_ap = "(:APCP:surface:)"
 
 # Merge matchstrings for download
@@ -182,7 +182,7 @@ match_strings = (
     + "|"
     + matchstring_10m
     + "|"
-    + matchstring_sl
+    + matchstring_1000m
     + "|"
     + matchstring_ap
 )
@@ -293,9 +293,9 @@ if spOUT3.returncode != 0:
 xarray_forecast_merged = xr.open_mfdataset(forecast_process_path + "_wgrib2_merged.nc")
 
 
-# Set REFC values < 5 to 0
-xarray_forecast_merged["REFC_entireatmosphere"] = mask_invalid_refc(
-    xarray_forecast_merged["REFC_entireatmosphere"]
+# Set REFD values < 5 to 0
+xarray_forecast_merged["REFD_1000maboveground"] = mask_invalid_refc(
+    xarray_forecast_merged["REFD_1000maboveground"]
 )
 
 if len(xarray_forecast_merged.time) != len(hrrr_range1) * 4:


### PR DESCRIPTION
## Describe the change
When I was changing the HRRR REFC products to REFD in https://github.com/Pirate-Weather/pirate-weather-code/pull/585 I missed changing the sub-hourly model so it was still using REFC_entireatmosphere instead of REFD_1000maboveground.

This PR fixes that omission by changing the sub-hourly HRRR to the REFD product like the other HRRR models and should improve minutely in the CONUS domain (see: https://github.com/Pirate-Weather/pirateweather/discussions/633)

It may be worth it to explore adding radar support in the future but for now this should fix the main currently/minutely precipitation issue.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [ ] The TimeMachine version (in API/timemachine.py) matches the API version number
