### PR TITLE
Remove medium and possible-heavy precipitation text

### DIFF
--- a/API/PirateTextHelper.py
+++ b/API/PirateTextHelper.py
@@ -305,13 +305,6 @@ def calculate_precip_text(
                 c_icon = "possible-rain-night"
             elif icon == "pirate":
                 c_icon = "heavy-rain"
-        if (  # This handles the case where over a week or multiple days there is heavy rain but each day individually does not meet the heavy threshold
-            # Some additional tweaking of this logic may be needed based on testing
-            (type == "minute" or type == "week")
-            and eff_rain_intensity < heavy_precip_thresh
-            and rainAccum >= heavy_precip_thresh * num_precip_days * 2
-        ):
-            c_text = ["and", "medium-rain", "possible-heavy-rain"]
     elif (snowAccum > 0 or eff_snow_intensity > 0) and precipType == PRECIP_TYPES[
         "snow"
     ]:
@@ -351,12 +344,6 @@ def calculate_precip_text(
                 c_icon = "possible-snow-night"
             elif icon == "pirate":
                 c_icon = "heavy-snow"
-        if (
-            (type == "week" or type == "hourly")
-            and snowAccum < (snow_icon_threshold * num_precip_days * 2)
-            and eff_snow_intensity >= heavy_snow_thresh
-        ):
-            c_text = ["and", "medium-snow", "possible-heavy-snow"]
     elif (sleetAccum > 0 or eff_ice_intensity > 0) and precipType == PRECIP_TYPES[
         "sleet"
     ]:
@@ -442,12 +429,6 @@ def calculate_precip_text(
                 c_icon = "possible-freezing-rain-night"
             elif icon == "pirate":
                 c_icon = "heavy-freezing-rain"
-        if (
-            (type == "week" or type == "hourly")
-            and sleetAccum < (precip_icon_threshold * num_precip_days * 2)
-            and eff_ice_intensity >= heavy_precip_thresh
-        ):
-            c_text = ["and", "medium-freezing-rain", "possible-heavy-freezing-rain"]
     elif (sleetAccum > 0 or eff_ice_intensity > 0) and precipType == PRECIP_TYPES[
         "hail"
     ]:
@@ -489,15 +470,6 @@ def calculate_precip_text(
             c_text = possible_precip + "medium-precipitation"
         else:
             c_text = possible_precip + "heavy-precipitation"
-        if (
-            (type == "week" or type == "hourly")
-            and (
-                (rainAccum + sleetAccum) < (precip_icon_threshold * 2)
-                or snowAccum < (snow_icon_threshold * 2)
-            )
-            and _none_intensity >= heavy_precip_thresh
-        ):
-            c_text = ["and", "medium-precipitation", "possible-heavy-precipitation"]
 
         if is_pirate_icon and is_possible_precip and isDayTime:
             c_icon = "possible-precipitation-day"

--- a/API/PirateTextHelper.py
+++ b/API/PirateTextHelper.py
@@ -383,12 +383,6 @@ def calculate_precip_text(
                 c_icon = "possible-sleet-night"
             elif icon == "pirate":
                 c_icon = "heavy-sleet"
-        if (
-            (type == "week" or type == "hourly")
-            and sleetAccum < (precip_icon_threshold * num_precip_days * 2)
-            and eff_ice_intensity >= heavy_precip_thresh
-        ):
-            c_text = ["and", "medium-sleet", "possible-heavy-sleet"]
 
     elif (sleetAccum > 0 or eff_ice_intensity > 0) and precipType == PRECIP_TYPES[
         "ice"

--- a/API/constants/api_const.py
+++ b/API/constants/api_const.py
@@ -120,7 +120,7 @@ PRECIP_ACCUM_NOISE_THRESHOLD = (
 
 # API versioning and ingest version constants
 # Version scheme is: Major.Minor.Patch
-API_VERSION = "V2.9.6"
+API_VERSION = "V2.9.7"
 
 # Generic API constants
 MAX_S3_RETRIES = 5


### PR DESCRIPTION
## Describe the change
The weekly summaries can produce summaries like this: Rain and possible heavy rain... but it often appears when there isn't any heavy precipitation forecast and causes unneeded clutter to the weekly summaries.

The weekly summaries should probably get overhauled at some point to better match the daily summaries but that is a project for a future day.

## Type of change

- [ ] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [x] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
- [ ] The TimeMachine version (in API/timemachine.py) matches the API version number
