### PR TITLE
Fix historic data chunking for GFS

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -137,7 +137,8 @@
                 "VIRTUAL_ENV": "${workspaceFolder}/.venvs/ingest-test",
                 "CMAKE_PREFIX_PATH": "${workspaceFolder}/.build/ingest-test/NCEPLIBS_build:${workspaceFolder}/.build/ingest-test/toolchain:${env:CMAKE_PREFIX_PATH}",
                 "PYDEVD_WARN_EVALUATION_TIMEOUT": "300",
-                "historic_path": "s3://piratezarr2/Hist_v2/GFS"
+                "historic_path": "s3://piratezarr2/Hist_v2/GFS",
+                "forecast_process_dir": "/mnt/nvme/data/GFS"
             },
             "envFile": "${workspaceFolder}/.env"
         },

--- a/API/GFS_Local_Ingest.py
+++ b/API/GFS_Local_Ingest.py
@@ -883,6 +883,16 @@ for hours_offset in range(his_period, 0, -6):
         storm_direction_hist.rechunk((6, process_chunk, process_chunk)).compute(),
     )
 
+    # Rechunk the rest of the variables in the merged dataset to the processing chunk size
+    xarray_hist_merged = xarray_hist_merged.chunk(
+        {
+            "time": 6,
+            "latitude": process_chunk,
+            "longitude": process_chunk,
+        }
+    )
+    
+
     # Clear memory
     del (
         ds_other_fields,

--- a/API/GFS_Local_Ingest.py
+++ b/API/GFS_Local_Ingest.py
@@ -891,7 +891,6 @@ for hours_offset in range(his_period, 0, -6):
             "longitude": process_chunk,
         }
     )
-    
 
     # Clear memory
     del (

--- a/API/GFS_Local_Ingest.py
+++ b/API/GFS_Local_Ingest.py
@@ -910,7 +910,6 @@ for hours_offset in range(his_period, 0, -6):
 
     # Save the dataset with compression and filters for all variables
     # Use the same encoding as last time but with larger chunks to speed up read times
-    # Small fix for PRES_station/ PRES_surface
     encoding = {
         vname: {"chunks": (6, process_chunk, process_chunk)} for vname in zarr_vars[1:]
     }

--- a/API/current/metrics.py
+++ b/API/current/metrics.py
@@ -1672,7 +1672,7 @@ def build_current_section(
     curr_cape_display = (
         int(np.round(InterPcurrent[DATA_CURRENT["cape"]], 0))
         if not np.isnan(InterPcurrent[DATA_CURRENT["cape"]])
-        else 0
+        else np.nan
     )
 
     dayZeroIce = float(np.round(dayZeroIce * prepAccumUnit, 4))


### PR DESCRIPTION
## Describe the change
Good news is that GFS ingest now runs; bad news is it was missing the rechunking step for the historic data processing. Fixed here, and just testing before merging it in.

## Type of change

- [X] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [ ] Code builds locally. **Your pull request won't be merged unless tests pass**
- [ ] Code has been formatted using ruff
- [ ] The TimeMachine version (in API/timemachine.py) matches the API version number
