### PR TITLE
Fix an issue where low PoP hours were counted toward thunderstorm total

### DIFF
--- a/API/PirateDailyText.py
+++ b/API/PirateDailyText.py
@@ -989,6 +989,10 @@ def calculate_day_text(
                     period_data["max_cape_with_precip"] = max(
                         period_data["max_cape_with_precip"], hour_cape
                     )
+                    # Count hours with thunderstorms (precipitation + CAPE >= low threshold)
+                    thu_text = calculate_thunderstorm_text(hour_cape, "summary")
+                    if thu_text is not None:
+                        period_data["num_hours_thunderstorm"] += 1
 
                 # Count hours with thunderstorms (precipitation + CAPE >= low threshold)
                 thu_text = calculate_thunderstorm_text(hour_cape, "summary")

--- a/API/PirateDailyText.py
+++ b/API/PirateDailyText.py
@@ -15,6 +15,7 @@ from API.constants.text_const import (
     DEFAULT_VISIBILITY,
     LESS_THAN_TOLERANCE,
     PRECIP_INTENSITY_THRESHOLDS,
+    PRECIP_PROB_THRESHOLD,
 )
 from API.PirateTextHelper import (
     calculate_precip_text,
@@ -982,12 +983,13 @@ def calculate_day_text(
 
                 # Track CAPE when there is precipitation
                 hour_cape = hour.get("cape", MISSING_DATA)
+                hour_pop = hour.get("precipProbability", DEFAULT_POP)
 
                 if (
                     hour_cape != MISSING_DATA
-                    and hour_cape > period_data["max_cape_with_precip"]
+                    and hour_pop >= PRECIP_PROB_THRESHOLD
                 ):
-                    period_data["max_cape_with_precip"] = hour_cape
+                    period_data["max_cape_with_precip"] = max(period_data["max_cape_with_precip"], hour_cape)
 
                 # Count hours with thunderstorms (precipitation + CAPE >= low threshold)
                 thu_text = calculate_thunderstorm_text(hour_cape, "summary")

--- a/API/PirateDailyText.py
+++ b/API/PirateDailyText.py
@@ -985,11 +985,10 @@ def calculate_day_text(
                 hour_cape = hour.get("cape", MISSING_DATA)
                 hour_pop = hour.get("precipProbability", DEFAULT_POP)
 
-                if (
-                    hour_cape != MISSING_DATA
-                    and hour_pop >= PRECIP_PROB_THRESHOLD
-                ):
-                    period_data["max_cape_with_precip"] = max(period_data["max_cape_with_precip"], hour_cape)
+                if hour_cape != MISSING_DATA and hour_pop >= PRECIP_PROB_THRESHOLD:
+                    period_data["max_cape_with_precip"] = max(
+                        period_data["max_cape_with_precip"], hour_cape
+                    )
 
                 # Count hours with thunderstorms (precipitation + CAPE >= low threshold)
                 thu_text = calculate_thunderstorm_text(hour_cape, "summary")

--- a/API/PirateDayNightText.py
+++ b/API/PirateDayNightText.py
@@ -14,6 +14,7 @@ from API.constants.text_const import (
     DEFAULT_VISIBILITY,
     LESS_THAN_TOLERANCE,
     PRECIP_INTENSITY_THRESHOLDS,
+    PRECIP_PROB_THRESHOLD,
 )
 from API.PirateTextHelper import (
     calculate_precip_text,
@@ -562,12 +563,13 @@ def calculate_half_day_text(
 
                 # Track CAPE when there is precipitation
                 hour_cape = hour.get("cape", MISSING_DATA)
+                hour_pop = hour.get("precipProbability", DEFAULT_POP)
 
                 if (
                     hour_cape != MISSING_DATA
-                    and hour_cape > period_data["max_cape_with_precip"]
+                    and hour_pop >= PRECIP_PROB_THRESHOLD
                 ):
-                    period_data["max_cape_with_precip"] = hour_cape
+                    period_data["max_cape_with_precip"] = max(period_data["max_cape_with_precip"], hour_cape)
 
                 # Count hours with thunderstorms (precipitation + CAPE >= low threshold)
                 thu_text = calculate_thunderstorm_text(hour_cape, "summary")

--- a/API/PirateDayNightText.py
+++ b/API/PirateDayNightText.py
@@ -565,11 +565,10 @@ def calculate_half_day_text(
                 hour_cape = hour.get("cape", MISSING_DATA)
                 hour_pop = hour.get("precipProbability", DEFAULT_POP)
 
-                if (
-                    hour_cape != MISSING_DATA
-                    and hour_pop >= PRECIP_PROB_THRESHOLD
-                ):
-                    period_data["max_cape_with_precip"] = max(period_data["max_cape_with_precip"], hour_cape)
+                if hour_cape != MISSING_DATA and hour_pop >= PRECIP_PROB_THRESHOLD:
+                    period_data["max_cape_with_precip"] = max(
+                        period_data["max_cape_with_precip"], hour_cape
+                    )
 
                 # Count hours with thunderstorms (precipitation + CAPE >= low threshold)
                 thu_text = calculate_thunderstorm_text(hour_cape, "summary")

--- a/API/PirateDayNightText.py
+++ b/API/PirateDayNightText.py
@@ -569,6 +569,10 @@ def calculate_half_day_text(
                     period_data["max_cape_with_precip"] = max(
                         period_data["max_cape_with_precip"], hour_cape
                     )
+                    # Count hours with thunderstorms (precipitation + CAPE >= low threshold)
+                    thu_text = calculate_thunderstorm_text(hour_cape, "summary")
+                    if thu_text is not None:
+                        period_data["num_hours_thunderstorm"] += 1
 
                 # Count hours with thunderstorms (precipitation + CAPE >= low threshold)
                 thu_text = calculate_thunderstorm_text(hour_cape, "summary")


### PR DESCRIPTION
## Describe the change
Fixes an issue where the daily thunderstorm calculation wasn't factoring PoP into its calculation so any hours with precipitation were counted toward the number of thunderstorm hours. This PR fixes that by factoring PoP into the calculation so low confident hours are filtered out.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [ ] Code builds locally. **Your pull request won't be merged unless tests pass**
- [ ] Code has been formatted using ruff
- [ ] The TimeMachine version (in API/timemachine.py) matches the API version number
