### PR TITLE
Fix thunderstorm icon issue by including PoP in calulcations

### DIFF
--- a/API/PirateDailyText.py
+++ b/API/PirateDailyText.py
@@ -1456,7 +1456,7 @@ def calculate_day_text(
     if has_thunderstorm:
         # Use max CAPE that occurred with precipitation
         thunderstorm_summary_text, thunderstorm_icon = calculate_thunderstorm_text(
-            overall_max_cape_with_precip, "both"
+            overall_max_cape_with_precip, "both", pop=overall_avg_pop 
         )
         # Check if thunderstorm periods match precipitation periods exactly
         if sorted(thunderstorm_periods) == sorted(precip_periods):

--- a/API/PirateDailyText.py
+++ b/API/PirateDailyText.py
@@ -990,14 +990,9 @@ def calculate_day_text(
                         period_data["max_cape_with_precip"], hour_cape
                     )
                     # Count hours with thunderstorms (precipitation + CAPE >= low threshold)
-                    thu_text = calculate_thunderstorm_text(hour_cape, "summary")
+                    thu_text = calculate_thunderstorm_text(hour_cape, "summary", pop=hour_pop)
                     if thu_text is not None:
                         period_data["num_hours_thunderstorm"] += 1
-
-                # Count hours with thunderstorms (precipitation + CAPE >= low threshold)
-                thu_text = calculate_thunderstorm_text(hour_cape, "summary")
-                if thu_text is not None:
-                    period_data["num_hours_thunderstorm"] += 1
 
     # Finalize `period_stats` list by only including periods that actually have data,
     # and in the correct order determined by `all_period_names_in_forecast_order`.

--- a/API/PirateDailyText.py
+++ b/API/PirateDailyText.py
@@ -990,7 +990,9 @@ def calculate_day_text(
                         period_data["max_cape_with_precip"], hour_cape
                     )
                     # Count hours with thunderstorms (precipitation + CAPE >= low threshold)
-                    thu_text = calculate_thunderstorm_text(hour_cape, "summary", pop=hour_pop)
+                    thu_text = calculate_thunderstorm_text(
+                        hour_cape, "summary", pop=hour_pop
+                    )
                     if thu_text is not None:
                         period_data["num_hours_thunderstorm"] += 1
 

--- a/API/PirateDailyText.py
+++ b/API/PirateDailyText.py
@@ -1456,7 +1456,7 @@ def calculate_day_text(
     if has_thunderstorm:
         # Use max CAPE that occurred with precipitation
         thunderstorm_summary_text, thunderstorm_icon = calculate_thunderstorm_text(
-            overall_max_cape_with_precip, "both", pop=overall_avg_pop 
+            overall_max_cape_with_precip, "both", pop=overall_avg_pop
         )
         # Check if thunderstorm periods match precipitation periods exactly
         if sorted(thunderstorm_periods) == sorted(precip_periods):

--- a/API/PirateDayNightText.py
+++ b/API/PirateDayNightText.py
@@ -977,7 +977,7 @@ def calculate_half_day_text(
     if has_thunderstorm:
         # Use max CAPE that occurred with precipitation
         thunderstorm_summary_text, thunderstorm_icon = calculate_thunderstorm_text(
-            overall_max_cape_with_precip, "both"
+            overall_max_cape_with_precip, "both", pop=overall_avg_pop
         )
         # Check if thunderstorm periods match precipitation periods exactly
         if sorted(thunderstorm_periods) == sorted(precip_periods):

--- a/API/PirateDayNightText.py
+++ b/API/PirateDayNightText.py
@@ -570,14 +570,9 @@ def calculate_half_day_text(
                         period_data["max_cape_with_precip"], hour_cape
                     )
                     # Count hours with thunderstorms (precipitation + CAPE >= low threshold)
-                    thu_text = calculate_thunderstorm_text(hour_cape, "summary")
+                    thu_text = calculate_thunderstorm_text(hour_cape, "summary", pop=hour_pop)
                     if thu_text is not None:
                         period_data["num_hours_thunderstorm"] += 1
-
-                # Count hours with thunderstorms (precipitation + CAPE >= low threshold)
-                thu_text = calculate_thunderstorm_text(hour_cape, "summary")
-                if thu_text is not None:
-                    period_data["num_hours_thunderstorm"] += 1
 
     # Finalize `period_stats` list by only including periods that actually have data,
     # and in the correct order determined by `all_period_names_in_forecast_order`.

--- a/API/PirateDayNightText.py
+++ b/API/PirateDayNightText.py
@@ -570,7 +570,9 @@ def calculate_half_day_text(
                         period_data["max_cape_with_precip"], hour_cape
                     )
                     # Count hours with thunderstorms (precipitation + CAPE >= low threshold)
-                    thu_text = calculate_thunderstorm_text(hour_cape, "summary", pop=hour_pop)
+                    thu_text = calculate_thunderstorm_text(
+                        hour_cape, "summary", pop=hour_pop
+                    )
                     if thu_text is not None:
                         period_data["num_hours_thunderstorm"] += 1
 

--- a/API/PirateText.py
+++ b/API/PirateText.py
@@ -114,7 +114,7 @@ def calculate_text(
     visText, visIcon = calculate_vis_text(
         vis, temp, dewPoint, wind, smoke, icon, "both"
     )
-    thuText, thuIcon = calculate_thunderstorm_text(cape, "both", icon, isDayTime)
+    thuText, thuIcon = calculate_thunderstorm_text(cape, mode="both", pop=pop, icon=icon, is_day=isDayTime)
     skyText, skyIcon = calculate_sky_text(cloudCover, isDayTime, icon, "both")
 
     # If there is precipitation text use that and join with wind texts if they exist

--- a/API/PirateText.py
+++ b/API/PirateText.py
@@ -114,7 +114,9 @@ def calculate_text(
     visText, visIcon = calculate_vis_text(
         vis, temp, dewPoint, wind, smoke, icon, "both"
     )
-    thuText, thuIcon = calculate_thunderstorm_text(cape, mode="both", pop=pop, icon=icon, is_day=isDayTime)
+    thuText, thuIcon = calculate_thunderstorm_text(
+        cape, mode="both", pop=pop, icon=icon, is_day=isDayTime
+    )
     skyText, skyIcon = calculate_sky_text(cloudCover, isDayTime, icon, "both")
 
     # If there is precipitation text use that and join with wind texts if they exist

--- a/API/PirateTextHelper.py
+++ b/API/PirateTextHelper.py
@@ -653,7 +653,9 @@ def calculate_sky_text(cloudCover, isDayTime, icon="darksky", mode="both"):
         return skyText, skyIcon
 
 
-def calculate_thunderstorm_text(cape, mode="both", pop=1.0, icon="darksky", is_day=True):
+def calculate_thunderstorm_text(
+    cape, mode="both", pop=1.0, icon="darksky", is_day=True
+):
     """
     Calculates the thunderstorm text based on CAPE values.
 

--- a/API/PirateTextHelper.py
+++ b/API/PirateTextHelper.py
@@ -653,12 +653,13 @@ def calculate_sky_text(cloudCover, isDayTime, icon="darksky", mode="both"):
         return skyText, skyIcon
 
 
-def calculate_thunderstorm_text(cape, mode="both", icon="darksky", is_day=True):
+def calculate_thunderstorm_text(cape, mode="both", pop=1.0, icon="darksky", is_day=True):
     """
     Calculates the thunderstorm text based on CAPE values.
 
     Parameters:
     - cape (float) -  The CAPE (Convective available potential energy)
+    - pop (float) - The precipitation probability (0.0 to 1.0)
     - mode (str): Determines what gets returned by the function. If set to both the summary and icon for the thunderstorm will be returned, if just icon then only the icon is returned and if summary then only the summary is returned.
     - icon (str): Which icon set to use - Dark Sky or Pirate Weather
     - is_day (bool): Whether it is day or night time
@@ -673,7 +674,10 @@ def calculate_thunderstorm_text(cape, mode="both", icon="darksky", is_day=True):
     if CAPE_THRESHOLDS["low"] <= cape < CAPE_THRESHOLDS["high"]:
         thuText = "possible-thunderstorm"
     elif cape >= CAPE_THRESHOLDS["high"]:
-        thuText = "thunderstorm"
+        if pop < PRECIP_PROB_THRESHOLD:
+            thuText = "possible-thunderstorm"
+        else:
+            thuText = "thunderstorm"
 
     if thuText == "thunderstorm":
         thuIcon = "thunderstorm"

--- a/API/PirateTextHelper.py
+++ b/API/PirateTextHelper.py
@@ -654,17 +654,17 @@ def calculate_sky_text(cloudCover, isDayTime, icon="darksky", mode="both"):
 
 
 def calculate_thunderstorm_text(
-    cape, mode="both", pop=1.0, icon="darksky", is_day=True
+    cape, mode="both", icon="darksky", is_day=True, pop=1.0
 ):
     """
     Calculates the thunderstorm text based on CAPE values.
 
     Parameters:
     - cape (float) -  The CAPE (Convective available potential energy)
-    - pop (float) - The precipitation probability (0.0 to 1.0)
     - mode (str): Determines what gets returned by the function. If set to both the summary and icon for the thunderstorm will be returned, if just icon then only the icon is returned and if summary then only the summary is returned.
     - icon (str): Which icon set to use - Dark Sky or Pirate Weather
     - is_day (bool): Whether it is day or night time
+    - pop (float) - The precipitation probability (0.0 to 1.0)
 
     Returns:
     - str | None: The textual representation of the thunderstorm
@@ -672,6 +672,12 @@ def calculate_thunderstorm_text(
     """
     thuText = None
     thuIcon = None
+
+    try:
+        if pop is None or np.isnan(pop):
+            pop = 1.0
+    except TypeError:
+        pop = 1.0
 
     if CAPE_THRESHOLDS["low"] <= cape < CAPE_THRESHOLDS["high"]:
         thuText = "possible-thunderstorm"


### PR DESCRIPTION
## Describe the change
Fix issue where thunderstorm summary can be shown if PoP < 25% if there is precipitation by downgrading it to the possible summary.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [ ] Code has been formatted using ruff
- [ ] The TimeMachine version (in API/timemachine.py) matches the API version number
