### PR TITLE
Update US EPA O3 breakpoints and set higher BLH minimum

### DIFF
--- a/API/constants/aqi_const.py
+++ b/API/constants/aqi_const.py
@@ -132,10 +132,10 @@ PM10_AQI = [0, 50, 100, 150, 200, 300, 400, 500]
 
 # O3 (Ozone, µg/m³) — EPA breakpoints converted to µg/m³ (1 ppm O3 ≈ 1996 µg/m³ @ 25°C)
 # Breakpoints for 8-hour average ozone concentrations
-O3_8H_BP = [0, 55, 71, 86, 106, 201]
+O3_8H_BP = [0, 54, 70, 85, 105, 200]
 O3_8H_AQI = [0, 50, 100, 150, 200, 300]
 # Breakpoints for 1-hour average ozone concentrations
-O3_1H_BP = [125, 165, 205, 405, 505, 605]
+O3_1H_BP = [124, 164, 204, 404, 504, 604]
 O3_1H_AQI = [100, 150, 200, 300, 400, 500]
 
 # NO2 (Nitrogen Dioxide, ppb) — EPA breakpoints
@@ -233,8 +233,8 @@ def compute_epa_aqi(
     if not math.isnan(o3_8h_ppb):
         o3_sub = _epa_sub_index(o3_8h_ppb, O3_8H_BP, O3_8H_AQI)
 
-    # 1-hour ozone only applies when 8-hour AQI > 100
-    if not math.isnan(o3_1h_ppb) and not math.isnan(o3_sub) and o3_sub > 100:
+    # 1-hour ozone only applies when 8-hour AQI > 100 and concentration is at least the minimum breakpoint
+    if not math.isnan(o3_1h_ppb) and not math.isnan(o3_sub) and o3_sub > 100 and o3_1h_ppb >= O3_1H_BP[0]:
         o3_1h_sub = _epa_sub_index(o3_1h_ppb, O3_1H_BP, O3_1H_AQI)
         if not math.isnan(o3_1h_sub):
             o3_sub = max(o3_sub, o3_1h_sub)

--- a/API/constants/aqi_const.py
+++ b/API/constants/aqi_const.py
@@ -234,11 +234,7 @@ def compute_epa_aqi(
         o3_sub = _epa_sub_index(o3_8h_ppb, O3_8H_BP, O3_8H_AQI)
 
     # 1-hour ozone only applies when 8-hour AQI > 100
-    if (
-        not math.isnan(o3_1h_ppb)
-        and not math.isnan(o3_sub)
-        and o3_sub > 100
-    ):
+    if not math.isnan(o3_1h_ppb) and not math.isnan(o3_sub) and o3_sub > 100:
         o3_1h_sub = _epa_sub_index(o3_1h_ppb, O3_1H_BP, O3_1H_AQI)
         if not math.isnan(o3_1h_sub):
             o3_sub = max(o3_sub, o3_1h_sub)

--- a/API/constants/aqi_const.py
+++ b/API/constants/aqi_const.py
@@ -132,9 +132,11 @@ PM10_AQI = [0, 50, 100, 150, 200, 300, 400, 500]
 
 # O3 (Ozone, µg/m³) — EPA breakpoints converted to µg/m³ (1 ppm O3 ≈ 1996 µg/m³ @ 25°C)
 # Breakpoints for 8-hour average ozone concentrations
-# Todo: Need to split these breakpoints into 8-hour and 1-hour ranges for EPA AQI calculation.
-O3_BP = [0, 108, 140, 170, 210, 400, 504, 604]
-O3_AQI = [0, 50, 100, 150, 200, 300, 400, 500]
+O3_8H_BP = [0, 55, 71, 86, 106, 201]
+O3_8H_AQI = [0, 50, 100, 150, 200, 300]
+# Breakpoints for 1-hour average ozone concentrations
+O3_1H_BP = [125, 165, 205, 405, 505, 605]
+O3_1H_AQI = [100, 150, 200, 300, 400, 500]
 
 # NO2 (Nitrogen Dioxide, ppb) — EPA breakpoints
 # Breakpoints for 1-hour average NO2 concentrations
@@ -211,7 +213,8 @@ def _epa_sub_index(conc_ug: float, bp: list, aqi_vals: list) -> float:
 def compute_epa_aqi(
     pm25_ug: float = float("nan"),
     pm10_ug: float = float("nan"),
-    o3_ppb: float = float("nan"),
+    o3_8h_ppb: float = float("nan"),
+    o3_1h_ppb: float = float("nan"),
     no2_ppb: float = float("nan"),
     so2_ppb: float = float("nan"),
     co_ppb: float = float("nan"),
@@ -220,16 +223,32 @@ def compute_epa_aqi(
 
     Pollutant concentrations should be in model-native units:
       pm25_ug, pm10_ug → µg/m³
-      o3_ppb, no2_ppb, so2_ppb, co_ppb → ppb
+      o3_8h_ppb, o3_1h_ppb, no2_ppb, so2_ppb, co_ppb → ppb
     """
     sub_indices = []
+
+    o3_sub = float("nan")
+
+    # 8-hour ozone
+    if not math.isnan(o3_8h_ppb):
+        o3_sub = _epa_sub_index(o3_8h_ppb, O3_8H_BP, O3_8H_AQI)
+
+    # 1-hour ozone only applies when 8-hour AQI > 100
+    if (
+        not math.isnan(o3_1h_ppb)
+        and not math.isnan(o3_sub)
+        and o3_sub > 100
+    ):
+        o3_1h_sub = _epa_sub_index(o3_1h_ppb, O3_1H_BP, O3_1H_AQI)
+        if not math.isnan(o3_1h_sub):
+            o3_sub = max(o3_sub, o3_1h_sub)
 
     if not math.isnan(pm25_ug):
         sub_indices.append(_epa_sub_index(pm25_ug, PM25_BP, PM25_AQI))
     if not math.isnan(pm10_ug):
         sub_indices.append(_epa_sub_index(pm10_ug, PM10_BP, PM10_AQI))
-    if not math.isnan(o3_ppb):
-        sub_indices.append(_epa_sub_index(o3_ppb * PPB_O3_TO_UG_M3, O3_BP, O3_AQI))
+    if not math.isnan(o3_sub):
+        sub_indices.append(o3_sub)
     if not math.isnan(no2_ppb):
         sub_indices.append(_epa_sub_index(no2_ppb, NO2_BP, NO2_AQI))
     if not math.isnan(so2_ppb):
@@ -416,6 +435,7 @@ def compute_aqi_array(
         # NO2 and SO2 use 1-hour (instantaneous) averages
         no2_calc = no2_v
         so2_calc = so2_v
+        o3_1h_calc = o3_v
     elif system == "AQHI":
         # AQHI uses 3-hour rolling averages for PM2.5, O3, NO2
         pm25_calc = rolling_mean(pm25_v, window=3)
@@ -436,13 +456,24 @@ def compute_aqi_array(
 
     result = np.full(n, np.nan, dtype=np.float32)
     for i in range(n):
-        result[i] = compute_aqi_for_unit_system(
-            unit_system,
-            float(pm25_calc[i]),
-            float(pm10_calc[i]),
-            float(o3_calc[i]),
-            float(no2_calc[i]),
-            float(so2_calc[i]),
-            float(co_calc[i]),
-        )
+        if system == "EPA":
+            result[i] = compute_epa_aqi(
+                pm25_ug=float(pm25_calc[i]),
+                pm10_ug=float(pm10_calc[i]),
+                o3_8h_ppb=float(o3_calc[i]),
+                o3_1h_ppb=float(o3_1h_calc[i]),
+                no2_ppb=float(no2_calc[i]),
+                so2_ppb=float(so2_calc[i]),
+                co_ppb=float(co_calc[i]),
+            )
+        else:
+            result[i] = compute_aqi_for_unit_system(
+                unit_system,
+                float(pm25_calc[i]),
+                float(pm10_calc[i]),
+                float(o3_calc[i]),
+                float(no2_calc[i]),
+                float(so2_calc[i]),
+                float(co_calc[i]),
+            )
     return result

--- a/API/constants/aqi_const.py
+++ b/API/constants/aqi_const.py
@@ -234,7 +234,12 @@ def compute_epa_aqi(
         o3_sub = _epa_sub_index(o3_8h_ppb, O3_8H_BP, O3_8H_AQI)
 
     # 1-hour ozone only applies when 8-hour AQI > 100 and concentration is at least the minimum breakpoint
-    if not math.isnan(o3_1h_ppb) and not math.isnan(o3_sub) and o3_sub > 100 and o3_1h_ppb >= O3_1H_BP[0]:
+    if (
+        not math.isnan(o3_1h_ppb)
+        and not math.isnan(o3_sub)
+        and o3_sub > 100
+        and o3_1h_ppb >= O3_1H_BP[0]
+    ):
         o3_1h_sub = _epa_sub_index(o3_1h_ppb, O3_1H_BP, O3_1H_AQI)
         if not math.isnan(o3_1h_sub):
             o3_sub = max(o3_sub, o3_1h_sub)

--- a/API/data_inputs.py
+++ b/API/data_inputs.py
@@ -939,10 +939,10 @@ def prepare_aq_inputs(
     # Convert PM_FRP_column from µg/m² (column burden) to µg/m³ (near-surface
     # concentration) by dividing by the boundary layer height.  When BLH is
     # NaN a neutral 1000 m is used; valid-but-small values are clamped to
-    # 100 m to avoid division by near-zero denominators.
+    # 500 m to avoid division by near-zero denominators.
     if silam_smoke_frp is not None:
         if silam_blh is not None:
-            blh = np.where(np.isnan(silam_blh), 1000.0, np.maximum(silam_blh, 100.0))
+            blh = np.where(np.isnan(silam_blh), 1000.0, np.maximum(silam_blh, 500.0))
         else:
             blh = np.full(num_hours, 1000.0)
         smoke_frp_m3 = silam_smoke_frp / blh

--- a/tests/test_aqi_calculations.py
+++ b/tests/test_aqi_calculations.py
@@ -354,7 +354,7 @@ class TestPrepareAQInputs:
         assert np.nanmean(result["smoke_frp"]) == pytest.approx(5.0, abs=0.1)
 
     def test_smoke_frp_enforces_minimum_blh(self):
-        """Valid BLH values below 100 m should be clamped to 100 m."""
+        """Valid BLH values below 500 m should be clamped to 500 m."""
         from API.constants.model_const import SILAM
 
         n = 4
@@ -371,12 +371,12 @@ class TestPrepareAQInputs:
                 "so2": np.full(n, 1.0),
                 "co": np.full(n, 100.0),
                 "pm_frp_column": np.full(n, 1000.0),
-                "blh": np.full(n, 10.0),  # valid but < 100 m → clamped to 100 m
+                "blh": np.full(n, 10.0),  # valid but < 500 m → clamped to 500 m
             },
         )
         result = prepare_aq_inputs(n, False, silam_data, hours)
-        # 1000 µg/m² / 100 m (clamped) = 10.0 µg/m³
-        assert np.nanmean(result["smoke_frp"]) == pytest.approx(10.0, abs=0.1)
+        # 1000 µg/m² / 500 m (clamped) = 2.0 µg/m³
+        assert np.nanmean(result["smoke_frp"]) == pytest.approx(2.0, abs=0.1)
 
     def test_smoke_frp_nans_when_silam_absent(self):
         """When SILAM is unavailable, smoke_frp should be all-NaN."""


### PR DESCRIPTION
## Describe the change
The US has two different breakpoints for Ozone - a 1-hour average Ozone and an 8-hour average Ozone. Each breakpoints do not span the whole range of possible values so if the AQI is over 100 either 1-hour or 8-hour is used depending on the maximum value.

Changed the BLH minimum to 500m from 100m to hopefully give better smoke metrics as it seems to show the maximum value of 500 a lot.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [ ] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
