### PR TITLE
Fix hourly UV being an integer

### DIFF
--- a/API/hourly/block.py
+++ b/API/hourly/block.py
@@ -599,7 +599,7 @@ def _build_hourly_display(
         DATA_HOURLY["prob"]: ROUNDING_RULES.get("precipProbability", 2),
         DATA_HOURLY["humidity"]: ROUNDING_RULES.get("humidity", 2),
         DATA_HOURLY["cloud"]: ROUNDING_RULES.get("cloudCover", 2),
-        DATA_HOURLY["uv"]: ROUNDING_RULES.get("uvIndex", 0),
+        DATA_HOURLY["uv"]: ROUNDING_RULES.get("uvIndex", 2),
         DATA_HOURLY["ozone"]: ROUNDING_RULES.get("ozone", 2),
         DATA_HOURLY["smoke"]: ROUNDING_RULES.get("smoke", 2),
         DATA_HOURLY["fire"]: ROUNDING_RULES.get("fireIndex", 2),
@@ -1045,7 +1045,7 @@ def build_hourly_objects(
                 hourly_display[idx, DATA_HOURLY["bearing"]]
             ),
             "cloudCover": hourly_display[idx, DATA_HOURLY["cloud"]],
-            "uvIndex": _nan_to_int_or_nan(hourly_display[idx, DATA_HOURLY["uv"]]),
+            "uvIndex": hourly_display[idx, DATA_HOURLY["uv"]],
             "visibility": hourly_display[idx, DATA_HOURLY["vis"]],
             "ozone": hourly_display[idx, DATA_HOURLY["ozone"]],
             "smoke": hourly_display[idx, DATA_HOURLY["smoke"]],


### PR DESCRIPTION
## Describe the change
Small bugfix to change the rounding rules for UVI being an integer when they should be rounded to 2 decimal places. The currently block is 2 decimal places for UVI and this keeps it consistent.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
