### PR TITLE
Fix SILAM Ingest

### DIFF
--- a/API/FMI_Silam_Local_Ingest.py
+++ b/API/FMI_Silam_Local_Ingest.py
@@ -139,7 +139,9 @@ def get_latest_silam_run():
 
     for catalog_url in catalog_urls:
         try:
-            headers = {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36"}
+            headers = {
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36"
+            }
             response = requests.get(catalog_url, headers=headers, timeout=30)
             response.raise_for_status()
             catalog = ElementTree.fromstring(response.content)

--- a/API/FMI_Silam_Local_Ingest.py
+++ b/API/FMI_Silam_Local_Ingest.py
@@ -139,7 +139,8 @@ def get_latest_silam_run():
 
     for catalog_url in catalog_urls:
         try:
-            response = requests.get(catalog_url, timeout=30)
+            headers = {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36"}
+            response = requests.get(catalog_url, headers=headers, timeout=30)
             response.raise_for_status()
             catalog = ElementTree.fromstring(response.content)
         except (ElementTree.ParseError, requests.RequestException) as e:
@@ -168,7 +169,8 @@ def get_latest_silam_run():
         logger.warning(f"No SILAM run files found in catalog {catalog_url}")
 
     # Fall back to the previous fixed-delay behavior if the catalog is unavailable.
-    latest_origintime = (datetime.now(timezone.utc) - timedelta(days=1)).replace(
+    # Use a two day delay to ensure files are available when the script runs.
+    latest_origintime = (datetime.now(timezone.utc) - timedelta(days=2)).replace(
         hour=0, minute=0, second=0, microsecond=0
     )
     logger.warning(f"Falling back to estimated SILAM run time: {latest_origintime}")


### PR DESCRIPTION
## Describe the change
@alexander0042 The FMI SILAM ingest has been broken since the first run so this should hopefully fix the issues. The code to check the XML files work but it could be getting blocked by their server so I added request headers so it hopefully won't get blocked.

I also changed the fixed delay to 2 days instead of 1 to make sure files are available when the script runs considering the files don't seem to be available until around 9am EDT which is likely after when the script runs.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [ ] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff
