### PR TITLE
Raise BLH minimum to 1000m to give better smoke data

### DIFF
--- a/API/data_inputs.py
+++ b/API/data_inputs.py
@@ -939,10 +939,10 @@ def prepare_aq_inputs(
     # Convert PM_FRP_column from µg/m² (column burden) to µg/m³ (near-surface
     # concentration) by dividing by the boundary layer height.  When BLH is
     # NaN a neutral 1000 m is used; valid-but-small values are clamped to
-    # 500 m to avoid division by near-zero denominators.
+    # 1000 m to avoid division by near-zero denominators.
     if silam_smoke_frp is not None:
         if silam_blh is not None:
-            blh = np.where(np.isnan(silam_blh), 1000.0, np.maximum(silam_blh, 500.0))
+            blh = np.where(np.isnan(silam_blh), 1000.0, np.maximum(silam_blh, 1000.0))
         else:
             blh = np.full(num_hours, 1000.0)
         smoke_frp_m3 = silam_smoke_frp / blh

--- a/tests/test_aqi_calculations.py
+++ b/tests/test_aqi_calculations.py
@@ -307,7 +307,7 @@ class TestPrepareAQInputs:
 
         n = 24
         hours = self._hour_array(n)
-        # PM_FRP_column = 2000 µg/m², BLH = 1000 m → expected smoke_frp = 1 µg/m³
+        # PM_FRP_column = 2000 µg/m², BLH = 1000 m → expected smoke_frp = 2 µg/m³
         silam_data = _make_zarr_data(
             n,
             SILAM,
@@ -325,7 +325,7 @@ class TestPrepareAQInputs:
         )
         result = prepare_aq_inputs(n, False, silam_data, hours)
         assert "smoke_frp" in result
-        assert np.nanmean(result["smoke_frp"]) == pytest.approx(1.0, abs=0.1)
+        assert np.nanmean(result["smoke_frp"]) == pytest.approx(2.0, abs=0.1)
 
     def test_smoke_frp_uses_default_blh_when_blh_missing(self):
         """When BLH is NaN or absent, smoke_frp should use a 1000 m neutral default."""
@@ -354,7 +354,7 @@ class TestPrepareAQInputs:
         assert np.nanmean(result["smoke_frp"]) == pytest.approx(5.0, abs=0.1)
 
     def test_smoke_frp_enforces_minimum_blh(self):
-        """Valid BLH values below 500 m should be clamped to 500 m."""
+        """Valid BLH values below 1000 m should be clamped to 1000 m."""
         from API.constants.model_const import SILAM
 
         n = 4
@@ -371,12 +371,12 @@ class TestPrepareAQInputs:
                 "so2": np.full(n, 1.0),
                 "co": np.full(n, 100.0),
                 "pm_frp_column": np.full(n, 1000.0),
-                "blh": np.full(n, 10.0),  # valid but < 500 m → clamped to 500 m
+                "blh": np.full(n, 10.0),  # valid but < 1000 m → clamped to 1000 m
             },
         )
         result = prepare_aq_inputs(n, False, silam_data, hours)
-        # 1000 µg/m² / 500 m (clamped) = 2.0 µg/m³
-        assert np.nanmean(result["smoke_frp"]) == pytest.approx(2.0, abs=0.1)
+        # 1000 µg/m² / 1000 m (clamped) = 1.0 µg/m³
+        assert np.nanmean(result["smoke_frp"]) == pytest.approx(1.0, abs=0.1)
 
     def test_smoke_frp_nans_when_silam_absent(self):
         """When SILAM is unavailable, smoke_frp should be all-NaN."""

--- a/tests/test_aqi_calculations.py
+++ b/tests/test_aqi_calculations.py
@@ -307,7 +307,7 @@ class TestPrepareAQInputs:
 
         n = 24
         hours = self._hour_array(n)
-        # PM_FRP_column = 2000 µg/m², BLH = 500 m → expected smoke_frp = 4 µg/m³
+        # PM_FRP_column = 2000 µg/m², BLH = 1000 m → expected smoke_frp = 2 µg/m³
         silam_data = _make_zarr_data(
             n,
             SILAM,
@@ -320,12 +320,12 @@ class TestPrepareAQInputs:
                 "so2": np.full(n, 1.0),
                 "co": np.full(n, 100.0),
                 "pm_frp_column": np.full(n, 2000.0),
-                "blh": np.full(n, 500.0),
+                "blh": np.full(n, 1000.0),
             },
         )
         result = prepare_aq_inputs(n, False, silam_data, hours)
         assert "smoke_frp" in result
-        assert np.nanmean(result["smoke_frp"]) == pytest.approx(4.0, abs=0.1)
+        assert np.nanmean(result["smoke_frp"]) == pytest.approx(2.0, abs=0.1)
 
     def test_smoke_frp_uses_default_blh_when_blh_missing(self):
         """When BLH is NaN or absent, smoke_frp should use a 1000 m neutral default."""

--- a/tests/test_aqi_calculations.py
+++ b/tests/test_aqi_calculations.py
@@ -307,7 +307,7 @@ class TestPrepareAQInputs:
 
         n = 24
         hours = self._hour_array(n)
-        # PM_FRP_column = 2000 µg/m², BLH = 1000 m → expected smoke_frp = 2 µg/m³
+        # PM_FRP_column = 2000 µg/m², BLH = 1000 m → expected smoke_frp = 1 µg/m³
         silam_data = _make_zarr_data(
             n,
             SILAM,
@@ -325,7 +325,7 @@ class TestPrepareAQInputs:
         )
         result = prepare_aq_inputs(n, False, silam_data, hours)
         assert "smoke_frp" in result
-        assert np.nanmean(result["smoke_frp"]) == pytest.approx(2.0, abs=0.1)
+        assert np.nanmean(result["smoke_frp"]) == pytest.approx(1.0, abs=0.1)
 
     def test_smoke_frp_uses_default_blh_when_blh_missing(self):
         """When BLH is NaN or absent, smoke_frp should use a 1000 m neutral default."""


### PR DESCRIPTION
## Describe the change
Looking through the SILAM smoke data for my location it's showing a maximum of 464.74 on Saturday which seems way too high. The updated minimum height while still gives high smoke values at least seems more realistic compared to what it was before.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [ ] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smoke concentration calculations by using a safer minimum boundary-layer height when converting SILAM inputs.
  * Updated smoke concentration results to reflect the new 1000 m minimum boundary-layer baseline.

* **Tests**
  * Updated smoke concentration expectations and assertions to match the revised boundary-layer height handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->