### PR TITLE
Update SILAM smoke estimations

### DIFF
--- a/API/data_inputs.py
+++ b/API/data_inputs.py
@@ -965,8 +965,9 @@ def prepare_aq_inputs(
 
         # --- Weight using surface PM2.5 ----------------------------------------
         if silam_pm25 is not None:
+            has_pm25 = np.isfinite(silam_pm25)
             weight = np.clip(silam_pm25 / 25.0, 0.10, 1.0)
-            smoke = raw_smoke * weight
+            weighted_smoke = raw_smoke * weight
 
             # --- Final cap -----------------------------------------------------
             max_factor = np.where(
@@ -983,7 +984,11 @@ def prepare_aq_inputs(
                 ),
             )
 
-            smoke = np.minimum(smoke, np.maximum(silam_pm25 * max_factor, 10.0))
+            capped_smoke = np.minimum(
+                weighted_smoke,
+                np.maximum(silam_pm25 * max_factor, 10.0),
+            )
+            smoke = np.where(has_pm25, capped_smoke, raw_smoke)
 
         else:
             smoke = raw_smoke

--- a/API/data_inputs.py
+++ b/API/data_inputs.py
@@ -951,7 +951,6 @@ def prepare_aq_inputs(
     # smoke" field comparable to HRRR, not a physically exact conversion.
 
     if silam_smoke_frp is not None:
-
         # --- Effective plume depth ---------------------------------------------
         if silam_blh is not None:
             effective_depth = np.where(
@@ -971,11 +970,14 @@ def prepare_aq_inputs(
 
             # --- Final cap -----------------------------------------------------
             max_factor = np.where(
-                silam_pm25 < 5.0, 2.0,
+                silam_pm25 < 5.0,
+                2.0,
                 np.where(
-                    silam_pm25 < 15.0, 3.0,
+                    silam_pm25 < 15.0,
+                    3.0,
                     np.where(
-                        silam_pm25 < 35.0, 4.0,
+                        silam_pm25 < 35.0,
+                        4.0,
                         5.0,
                     ),
                 ),

--- a/API/data_inputs.py
+++ b/API/data_inputs.py
@@ -936,16 +936,58 @@ def prepare_aq_inputs(
         out[nan_mask] = fallback[nan_mask]
         return out
 
-    # Convert PM_FRP_column from µg/m² (column burden) to µg/m³ (near-surface
-    # concentration) by dividing by the boundary layer height.  When BLH is
-    # NaN a neutral 1000 m is used; valid-but-small values are clamped to
-    # 1000 m to avoid division by near-zero denominators.
+    # Estimate near-surface smoke concentration from SILAM PM_FRP column.
+    #
+    # PM_FRP_column is a vertically integrated fire PM burden (µg/m²), not a
+    # surface concentration. Since the vertical distribution is unavailable in
+    # the surface product, we approximate a surface concentration by:
+    #
+    #   1. Dividing by an effective plume depth (rather than BLH alone).
+    #   2. Scaling according to the modeled surface PM2.5.
+    #   3. Capping the result relative to PM2.5 to avoid unrealistic cases where
+    #      estimated smoke greatly exceeds the total surface particulate mass.
+    #
+    # This is an empirical approximation intended to produce a stable "surface
+    # smoke" field comparable to HRRR, not a physically exact conversion.
+
     if silam_smoke_frp is not None:
+
+        # --- Effective plume depth ---------------------------------------------
         if silam_blh is not None:
-            blh = np.where(np.isnan(silam_blh), 1000.0, np.maximum(silam_blh, 1000.0))
+            effective_depth = np.where(
+                np.isnan(silam_blh),
+                3000.0,
+                np.clip(silam_blh * 3.0, 2000.0, 6000.0),
+            )
         else:
-            blh = np.full(num_hours, 1000.0)
-        smoke_frp_m3 = silam_smoke_frp / blh
+            effective_depth = np.full(num_hours, 3000.0)
+
+        raw_smoke = silam_smoke_frp / effective_depth
+
+        # --- Weight using surface PM2.5 ----------------------------------------
+        if silam_pm25 is not None:
+            weight = np.clip(silam_pm25 / 25.0, 0.10, 1.0)
+            smoke = raw_smoke * weight
+
+            # --- Final cap -----------------------------------------------------
+            max_factor = np.where(
+                silam_pm25 < 5.0, 2.0,
+                np.where(
+                    silam_pm25 < 15.0, 3.0,
+                    np.where(
+                        silam_pm25 < 35.0, 4.0,
+                        5.0,
+                    ),
+                ),
+            )
+
+            smoke = np.minimum(smoke, np.maximum(silam_pm25 * max_factor, 10.0))
+
+        else:
+            smoke = raw_smoke
+
+        smoke_frp_m3 = smoke
+
     else:
         smoke_frp_m3 = nan_row.copy()
 

--- a/tests/test_aqi_calculations.py
+++ b/tests/test_aqi_calculations.py
@@ -307,7 +307,10 @@ class TestPrepareAQInputs:
 
         n = 24
         hours = self._hour_array(n)
-        # PM_FRP_column = 2000 µg/m², BLH = 1000 m → expected smoke_frp = 2 µg/m³
+        # PM_FRP_column = 2000 µg/m², BLH = 1000 m, PM2.5 = 5 µg/m³
+        # Effective plume depth = 3000 m, weighting = 0.20
+        # Raw smoke = 2000 / 3000 = 0.67 µg/m³
+        # Expected smoke_frp ≈ 0.13 µg/m³
         silam_data = _make_zarr_data(
             n,
             SILAM,
@@ -325,15 +328,15 @@ class TestPrepareAQInputs:
         )
         result = prepare_aq_inputs(n, False, silam_data, hours)
         assert "smoke_frp" in result
-        assert np.nanmean(result["smoke_frp"]) == pytest.approx(2.0, abs=0.1)
+        assert np.nanmean(result["smoke_frp"]) == pytest.approx(0.1, abs=0.1)
 
     def test_smoke_frp_uses_default_blh_when_blh_missing(self):
-        """When BLH is NaN or absent, smoke_frp should use a 1000 m neutral default."""
+        """When BLH is NaN or absent, smoke_frp should use a 3000 m neutral default."""
         from API.constants.model_const import SILAM
 
         n = 24
         hours = self._hour_array(n)
-        # BLH column not provided → extracted as NaN → default 1000 m applied
+        # BLH column not provided → extracted as NaN → default 3000 m applied
         silam_data = _make_zarr_data(
             n,
             SILAM,
@@ -350,11 +353,13 @@ class TestPrepareAQInputs:
         )
         result = prepare_aq_inputs(n, False, silam_data, hours)
         assert "smoke_frp" in result
-        # 5000 µg/m² / 1000 m (NaN BLH → neutral 1000 m default) = 5.0 µg/m³
-        assert np.nanmean(result["smoke_frp"]) == pytest.approx(5.0, abs=0.1)
+        # PM_FRP_column = 5000 µg/m², BLH = NaN (default 3000 m), PM2.5 = 5 µg/m³
+        # Raw smoke = 5000 / 3000 = 1.67 µg/m³
+        # Expected smoke_frp ≈ 0.33 µg/m³
+        assert np.nanmean(result["smoke_frp"]) == pytest.approx(0.3, abs=0.1)
 
     def test_smoke_frp_enforces_minimum_blh(self):
-        """Valid BLH values below 1000 m should be clamped to 1000 m."""
+        """Valid BLH values below 2000 m should be clamped to 2000 m."""
         from API.constants.model_const import SILAM
 
         n = 4
@@ -371,12 +376,14 @@ class TestPrepareAQInputs:
                 "so2": np.full(n, 1.0),
                 "co": np.full(n, 100.0),
                 "pm_frp_column": np.full(n, 1000.0),
-                "blh": np.full(n, 10.0),  # valid but < 1000 m → clamped to 1000 m
+                "blh": np.full(n, 10.0),  # valid but < 2000 m → clamped to 2000 m
             },
         )
         result = prepare_aq_inputs(n, False, silam_data, hours)
-        # 1000 µg/m² / 1000 m (clamped) = 1.0 µg/m³
-        assert np.nanmean(result["smoke_frp"]) == pytest.approx(1.0, abs=0.1)
+        # PM_FRP_column = 1000 µg/m², BLH = 200 m (minimum effective depth = 2000 m), PM2.5 = 5 µg/m³
+        # Raw smoke = 1000 / 2000 = 0.50 µg/m³
+        # Expected smoke_frp ≈ 0.10 µg/m³
+        assert np.nanmean(result["smoke_frp"]) == pytest.approx(0.1, abs=0.1)
 
     def test_smoke_frp_nans_when_silam_absent(self):
         """When SILAM is unavailable, smoke_frp should be all-NaN."""


### PR DESCRIPTION
## Describe the change
Instead of just using a straight BLH estimation which can overestimate smoke concentrations compared to the PM2.5 product. While BLH is still used in the estimation we also scale based on surface PM2.5 from the same product so we don't get 250 ug/m3 of smoke with 7.7 ug/m3 from the PM2.5 product.

Should also mention that this was built with the help of ChatGPT and I did do my own review to verify the code.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smoke pollution estimates using more accurate plume-depth assumptions.
  * Adjusted handling of missing or unusually low boundary-layer data.
  * Added PM2.5-based scaling and safeguards to reduce unrealistic smoke estimates.
  * Updated smoke estimation validation for SILAM data and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->