### PR TITLE
Change CAQI to Normalized EAQI using the CAQI 0-100 scale

### DIFF
--- a/API/constants/aqi_const.py
+++ b/API/constants/aqi_const.py
@@ -319,7 +319,7 @@ def compute_caqi(
     no2_ppb: float = float("nan"),
     so2_ppb: float = float("nan"),
 ) -> float:
-    """Compute EU Common Air Quality Index (0–100+ scale).
+    """Compute the European Air Quality Index (EAQI) on the legacy CAQI scale.
 
     Returns the maximum sub-index across available pollutants.
     """
@@ -374,8 +374,8 @@ def compute_aqi_for_unit_system(
         return compute_epa_aqi(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb, co_ppb)
     elif system == "AQHI":
         return compute_aqhi(pm25_ug, o3_ppb, no2_ppb)
-    else:  # CAQI
-        return compute_caqi(pm25_ug, pm10_ug, o3_ppb, no2_ppb)
+    else:  # EAQI
+        return compute_caqi(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb)
 
 
 def compute_aqi_array(
@@ -452,7 +452,7 @@ def compute_aqi_array(
         so2_calc = so2_v
         co_calc = co_v
     else:
-        # EAQI use raw hourly concentrations
+        # EAQI uses raw hourly concentrations
         pm25_calc = pm25_v
         pm10_calc = pm10_v
         o3_calc = o3_v

--- a/API/constants/aqi_const.py
+++ b/API/constants/aqi_const.py
@@ -163,15 +163,16 @@ PPB_SO2_TO_UG_M3 = 2.62  # 1 ppb SO2 ≈ 2.62  µg/m³
 PPB_CO_TO_UG_M3 = 1.145  # 1 ppb CO  ≈ 1.145 µg/m³
 
 # ---------------------------------------------------------------------------
-# EU CAQI breakpoints (µg/m³ for all species)
-# Reference: https://www.airqualitynow.eu/about_indices_definition.php
+# Normalized EU EAQI breakpoints (µg/m³ for all species)
+# Reference: https://airindex.eea.europa.eu/AQI/index.html
 # Roadside index uses the same ranges as background for the species we expose.
 # ---------------------------------------------------------------------------
-CAQI_PM25_BP = [0, 15, 30, 55, 110]
-CAQI_PM10_BP = [0, 25, 50, 90, 180]
-CAQI_O3_BP = [0, 60, 120, 180, 240]  # µg/m³
-CAQI_NO2_BP = [0, 50, 100, 200, 400]  # µg/m³
-CAQI_INDEX = [0, 25, 50, 75, 100]  # CAQI 0–100
+EAQI_PM25_BP = [0, 5, 15, 50, 90, 140]
+EAQI_PM10_BP = [0, 15, 45, 120, 195, 270]
+EAQI_O3_BP = [0, 60, 100, 120, 160, 180]  # µg/m³
+EAQI_NO2_BP = [0, 10, 25, 60, 100, 150]  # µg/m³
+EAQI_SO2_BP = [0, 20, 40, 125, 190, 275]  # µg/m³
+EAQI_INDEX = [0, 20, 40, 60, 80, 100]  # EAQI 0–100
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -316,6 +317,7 @@ def compute_caqi(
     pm10_ug: float = float("nan"),
     o3_ppb: float = float("nan"),
     no2_ppb: float = float("nan"),
+    so2_ppb: float = float("nan"),
 ) -> float:
     """Compute EU Common Air Quality Index (0–100+ scale).
 
@@ -323,16 +325,19 @@ def compute_caqi(
     """
     o3_ug = o3_ppb * PPB_O3_TO_UG_M3 if not math.isnan(o3_ppb) else float("nan")
     no2_ug = no2_ppb * PPB_NO2_TO_UG_M3 if not math.isnan(no2_ppb) else float("nan")
+    so2_ug = so2_ppb * PPB_SO2_TO_UG_M3 if not math.isnan(so2_ppb) else float("nan")
 
     sub_indices = []
     if not math.isnan(pm25_ug):
-        sub_indices.append(_aqi_from_breakpoints(pm25_ug, CAQI_PM25_BP, CAQI_INDEX))
+        sub_indices.append(_aqi_from_breakpoints(pm25_ug, EAQI_PM25_BP, EAQI_INDEX))
     if not math.isnan(pm10_ug):
-        sub_indices.append(_aqi_from_breakpoints(pm10_ug, CAQI_PM10_BP, CAQI_INDEX))
+        sub_indices.append(_aqi_from_breakpoints(pm10_ug, EAQI_PM10_BP, EAQI_INDEX))
     if not math.isnan(o3_ug):
-        sub_indices.append(_aqi_from_breakpoints(o3_ug, CAQI_O3_BP, CAQI_INDEX))
+        sub_indices.append(_aqi_from_breakpoints(o3_ug, EAQI_O3_BP, EAQI_INDEX))
     if not math.isnan(no2_ug):
-        sub_indices.append(_aqi_from_breakpoints(no2_ug, CAQI_NO2_BP, CAQI_INDEX))
+        sub_indices.append(_aqi_from_breakpoints(no2_ug, EAQI_NO2_BP, EAQI_INDEX))
+    if not math.isnan(so2_ug):
+        sub_indices.append(_aqi_from_breakpoints(so2_ug, EAQI_SO2_BP, EAQI_INDEX))
 
     valid = [v for v in sub_indices if not math.isnan(v)]
     return float(max(valid)) if valid else float("nan")
@@ -447,7 +452,7 @@ def compute_aqi_array(
         so2_calc = so2_v
         co_calc = co_v
     else:
-        # CAQI use raw hourly concentrations
+        # EAQI use raw hourly concentrations
         pm25_calc = pm25_v
         pm10_calc = pm10_v
         o3_calc = o3_v

--- a/tests/test_aqi_calculations.py
+++ b/tests/test_aqi_calculations.py
@@ -90,7 +90,7 @@ class TestAQHI:
 
 class TestCAQI:
     def test_low_pollutants_return_low_caqi(self):
-        caqi = compute_caqi(pm25_ug=5.0, pm10_ug=10.0, o3_ppb=20.0, no2_ppb=5.0, so2_ppb=8.0)
+        caqi = compute_caqi(pm25_ug=5.0, pm10_ug=10.0, o3_ppb=20.0, no2_ppb=5.0, so2_ppb=7.0)
         assert 0 <= caqi <= 20
 
     def test_high_pollutants_return_high_caqi(self):

--- a/tests/test_aqi_calculations.py
+++ b/tests/test_aqi_calculations.py
@@ -90,11 +90,11 @@ class TestAQHI:
 
 class TestCAQI:
     def test_low_pollutants_return_low_caqi(self):
-        caqi = compute_caqi(pm25_ug=5.0, pm10_ug=10.0, o3_ppb=20.0, no2_ppb=10.0)
-        assert 0 <= caqi <= 25
+        caqi = compute_caqi(pm25_ug=5.0, pm10_ug=10.0, o3_ppb=20.0, no2_ppb=5.0, so2_ppb=8.0)
+        assert 0 <= caqi <= 20
 
     def test_high_pollutants_return_high_caqi(self):
-        caqi = compute_caqi(pm25_ug=80.0, pm10_ug=100.0, o3_ppb=300.0, no2_ppb=200.0)
+        caqi = compute_caqi(pm25_ug=80.0, pm10_ug=100.0, o3_ppb=300.0, no2_ppb=200.0, so2_ppb=90.0)
         assert caqi >= 75
 
     def test_nan_inputs_return_nan(self):


### PR DESCRIPTION
## Describe the change
The API was using the outdated the outdated CAQI for the EU index so I updated it with the 2024 EAQI breakpoints. The EAQI uses a 1-6 scale similarly to AQHI but in order to not break things I changed it to a normalized scale using the same 0-100 values that CAQI used.

I think we should probably update to use the proper EAQI scale in the future but for now this normalized scale will work.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated air quality calculations to use the normalized 0–100 EAQI scale.
  * Added sulfur dioxide (SO₂) to air quality assessments.
  * Improved SO₂ unit handling for more accurate readings.
  * Updated air quality results and validation ranges to reflect the revised index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->