### PR TITLE
Add more air quality indexes

### DIFF
--- a/API/constants/aqi_const.py
+++ b/API/constants/aqi_const.py
@@ -5,6 +5,7 @@ Supports three AQI systems:
   - Canadian AQHI (unit_system="ca")
   - EU CAQI     (unit_system="si")
   - UK DAQI      (unit_system="uk")
+  - Hong Kong AQHI (aqisystem="hk")
 
 All input concentrations use the model-native units:
   - PM2.5, PM10: µg/m³
@@ -16,6 +17,7 @@ References:
     - Health Canada AQHI: https://www.canada.ca/en/environment-climate-change/services/air-quality-health-index.html
     - EU CAQI: https://www.airqualitynow.eu/about_indices_definition.php
     - UK DAQI: https://aqihub.info/indices/uk
+    - Hong Kong AQHI: https://www.aqhi.gov.hk/en.html
 """
 
 from __future__ import annotations
@@ -185,6 +187,13 @@ DAQI_O3_BP = [0, 34, 67, 101, 121, 141, 161, 188, 214, 241]  # µg/m³
 DAQI_NO2_BP = [0, 68, 135, 201, 268, 335, 401, 468, 535, 601]  # µg/m³
 DAQI_SO2_BP = [0, 89, 178, 267, 355, 444, 533, 711, 888, 1065]  # µg/m³
 DAQI_INDEX = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]  # DAQI 1–10
+
+# ---------------------------------------------------------------------------
+# Ireland AQIH breakpoints (µg/m³ for all species)
+# Reference: https://aqihub.info/indices/ireland
+# ---------------------------------------------------------------------------
+# The Irish AQIH uses the same breakpoints as the UK DAQI, but the SO2 breakpoints are slightly different. The AQIH SO2 breakpoints are:
+AQIH_SO2_BP = [0, 30, 60, 90, 120, 150, 180, 237, 296, 355]  # µg/m³
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -475,6 +484,51 @@ def compute_daqi(
 
 
 # ---------------------------------------------------------------------------
+# Ireland AQIH
+# ---------------------------------------------------------------------------
+
+
+def compute_aqih(
+    pm25_ug: float = float("nan"),
+    pm10_ug: float = float("nan"),
+    o3_ppb: float = float("nan"),
+    no2_ppb: float = float("nan"),
+    so2_ppb: float = float("nan"),
+) -> float:
+    """Compute Ireland AQIH as the maximum sub-index across available pollutants. AQIH uses the same breakpoints as the UK DAQI, but the SO2 breakpoints are slightly different.
+
+    For the AQIH system the appropriate averaging periods are applied
+    before the breakpoint lookup:
+      - PM2.5, PM10: 24-hour rolling mean
+      - O3: 8-hour rolling mean
+      - NO2: 1-hour (no additional averaging)
+      - SO2: 1-hour (no additional averaging)
+
+    Pollutant concentrations should be in model-native units:
+      pm25_ug, pm10_ug → µg/m³
+      o3_ppb, no2_ppb, so2_ppb, co_ppb → ppb
+    """
+
+    o3_ug = o3_ppb * PPB_O3_TO_UG_M3 if not math.isnan(o3_ppb) else float("nan")
+    no2_ug = no2_ppb * PPB_NO2_TO_UG_M3 if not math.isnan(no2_ppb) else float("nan")
+    so2_ug = so2_ppb * PPB_SO2_TO_UG_M3 if not math.isnan(so2_ppb) else float("nan")
+
+    sub_indices = []
+    if not math.isnan(o3_ug):
+        sub_indices.append(_index_from_breakpoints(o3_ug, DAQI_O3_BP, DAQI_INDEX))
+    if not math.isnan(pm25_ug):
+        sub_indices.append(_index_from_breakpoints(pm25_ug, DAQI_PM25_BP, DAQI_INDEX))
+    if not math.isnan(pm10_ug):
+        sub_indices.append(_index_from_breakpoints(pm10_ug, DAQI_PM10_BP, DAQI_INDEX))
+    if not math.isnan(no2_ug):
+        sub_indices.append(_index_from_breakpoints(no2_ug, DAQI_NO2_BP, DAQI_INDEX))
+    if not math.isnan(so2_ug):
+        sub_indices.append(_index_from_breakpoints(so2_ug, AQIH_SO2_BP, DAQI_INDEX))
+
+    valid = [v for v in sub_indices if not math.isnan(v)]
+    return float(max(valid)) if valid else float("nan")
+
+# ---------------------------------------------------------------------------
 # Unified dispatcher
 # ---------------------------------------------------------------------------
 
@@ -485,6 +539,7 @@ AQI_SYSTEM_MAP = {
     "uk": "DAQI",
     "si": "CAQI",
     "hk": "HK_AQHI",
+    "ie": "AQIH",
 }
 
 
@@ -510,6 +565,8 @@ def compute_aqi_for_unit_system(
         return compute_daqi(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb)
     elif system == "HK_AQHI":
         return compute_hk_aqhi(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb)
+    elif system == "AQIH":
+        return compute_aqih(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb)
     else:  # EAQI
         return compute_caqi(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb)
 
@@ -588,8 +645,8 @@ def compute_aqi_array(
         pm25_calc = rolling_mean(pm25_v, window=3)
         o3_calc = rolling_mean(o3_v, window=3)
         no2_calc = rolling_mean(no2_v, window=3)
-    elif system == "DAQI":
-        # DAQI uses 24-hour rolling averages for PM2.5 and PM10, 8-hour for O3, and 15-minute for SO2
+    elif system == "DAQI" or system == "AQIH":
+        # DAQI and AQIH use 24-hour rolling averages for PM2.5 and PM10, 8-hour for O3
         pm25_calc = rolling_mean(pm25_v, window=24)
         pm10_calc = rolling_mean(pm10_v, window=24)
         o3_calc = rolling_mean(o3_v, window=8)

--- a/API/constants/aqi_const.py
+++ b/API/constants/aqi_const.py
@@ -342,7 +342,7 @@ HK_AQHI_BETA_NO2 = 0.0004462559  # Coefficient expects µg/m³
 HK_AQHI_BETA_PM25 = 0.0002180567  # Coefficient expects µg/m³
 HK_AQHI_BETA_PM10 = 0.0002821751  # Coefficient expects µg/m³
 HK_AQHI_BETA_SO2 = 0.0001393235  # Coefficient expects µg/m³
-HK_AR_BP = [1.89, 3.77, 5.65, 7.53, 9.42, 11.30, 12.92, 15.08, 17.23, 19.38]
+HK_AR_BP = [0, 1.89, 3.77, 5.65, 7.53, 9.42, 11.30, 12.92, 15.08, 17.23, 19.38]
 HK_AQHI = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 
 
@@ -360,6 +360,10 @@ def compute_hk_aqhi(
     so2 = so2_ppb * PPB_SO2_TO_UG_M3 if not math.isnan(so2_ppb) else float("nan")
     pm25 = pm25_ug if not math.isnan(pm25_ug) else float("nan")
     pm10 = pm10_ug if not math.isnan(pm10_ug) else float("nan")
+
+    # Default PM Variables to NaN
+    pm25_ar = float("nan")
+    pm10_ar = float("nan")
 
     pm_ar = 0.0
     count = 0
@@ -480,6 +484,7 @@ AQI_SYSTEM_MAP = {
     "ca": "AQHI",
     "uk": "DAQI",
     "si": "CAQI",
+    "hk": "HK_AQHI",
 }
 
 
@@ -503,6 +508,8 @@ def compute_aqi_for_unit_system(
         return compute_aqhi(pm25_ug, o3_ppb, no2_ppb)
     elif system == "DAQI":
         return compute_daqi(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb)
+    elif system == "HK_AQHI":
+        return compute_hk_aqhi(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb)
     else:  # EAQI
         return compute_caqi(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb)
 
@@ -586,6 +593,13 @@ def compute_aqi_array(
         pm25_calc = rolling_mean(pm25_v, window=24)
         pm10_calc = rolling_mean(pm10_v, window=24)
         o3_calc = rolling_mean(o3_v, window=8)
+    elif system == "HK_AQHI":
+        # Hong Kong AQHI uses 3-hour rolling averages for PM2.5, PM10, O3, NO2, SO2
+        pm25_calc = rolling_mean(pm25_v, window=3)
+        pm10_calc = rolling_mean(pm10_v, window=3)
+        o3_calc = rolling_mean(o3_v, window=3)
+        no2_calc = rolling_mean(no2_v, window=3)
+        so2_calc = rolling_mean(so2_v, window=3)
 
     result = np.full(n, np.nan, dtype=np.float32)
     for i in range(n):

--- a/API/constants/aqi_const.py
+++ b/API/constants/aqi_const.py
@@ -11,7 +11,6 @@ Supports three AQI systems:
   - Indonesia ISPU (aqisystem="id")
   - China AQI (aqisystem="cn")
   - Malaysia API (aqisystem="my")
-  - Taiwan AQI (aqisystem="tw")
   - Vietnam VN_AQI (aqisystem="vn")
 
 All input concentrations use the model-native units:
@@ -30,7 +29,6 @@ References:
     - Indonesia ISPU: https://aqihub.info/indices/indonesia
     - China AQI: https://aqihub.info/indices/china
     - Malaysia API: https://aqihub.info/indices/malaysia
-    - Taiwan AQI: https://aqihub.info/indices/taiwan
     - Vietnam VN_AQI: https://aqihub.info/indices/vietnam
 """
 
@@ -265,19 +263,6 @@ API_NO2_BP = [0, 106, 178, 249, 320, 642]
 API_SO2_BP = [0, 134, 172, 210, 249, 500]
 API_CO_BP = [0, 3000, 4000, 5000, 6000, 12000]
 API_INDEX = [0, 50, 100, 200, 300, 500]  # API 0–500
-
-# ---------------------------------------------------------------------------
-# Taiwan AQI breakpoints (µg/m³ for PM and ppb for NO2 and SO2 and ppm for CO and O3)
-# Reference: https://aqihub.info/indices/taiwan
-# ---------------------------------------------------------------------------
-TAQI_PM25_BP = [0, 15.4, 35.4, 54.4, 150.4, 250.4, 500.4]
-TAQI_PM10_BP = [0, 50, 100, 254, 354, 424, 604]
-TAQI_O3_1H_BP = [0, 0, 124, 164, 204, 404, 604]
-TAQI_O3_8H_BP = [0, 54, 70, 85, 105, 200, 200]
-TAQI_NO2_BP = [0, 30, 100, 360, 649, 1249, 2049]
-TAQI_SO2_BP = [0, 20, 75, 185, 304, 604, 605]
-TAQI_CO_BP = [0, 4400, 9400, 12400, 15400, 30400, 60400]
-TAQI_INDEX = [0, 50, 100, 150, 200, 300, 500]  # Taiwan 0–500
 
 # ---------------------------------------------------------------------------
 # Vietnam VN_AQI breakpoints (µg/m³ for all species)
@@ -918,63 +903,6 @@ def compute_api(
 
 
 # ---------------------------------------------------------------------------
-# Taiwan AQI
-# ---------------------------------------------------------------------------
-
-
-def compute_taiwan_aqi(
-    pm25_ug: float = float("nan"),
-    pm10_ug: float = float("nan"),
-    o3_8h_ppb: float = float("nan"),
-    o3_1h_ppb: float = float("nan"),
-    no2_ppb: float = float("nan"),
-    so2_ppb: float = float("nan"),
-    co_ppb: float = float("nan"),
-) -> float:
-    """Compute Taiwan AQI as the maximum sub-index across available pollutants."""
-    sub_indices = []
-
-    # Initialize all sub-index values to NaN
-    o3_sub = float("nan")
-    sub_1h = float("nan")
-    sub_8h = float("nan")
-
-    # 1. Calculate 8-hour sub-index (valid up to AQI 300)
-    if not math.isnan(o3_8h_ppb):
-        # 8-hr table caps at 200 ppb (AQI 300)
-        sub_8h = _aqi_from_breakpoints(o3_8h_ppb, TAQI_O3_8H_BP, TAQI_INDEX)
-
-    # 2. Calculate 1-hour sub-index (only evaluated if >= 125 ppb / AQI >= 101)
-    if not math.isnan(o3_1h_ppb) and o3_1h_ppb >= 125.0:
-        sub_1h = _aqi_from_breakpoints(o3_1h_ppb, TAQI_O3_1H_BP, TAQI_INDEX)
-
-    # 3. Handle threshold boundaries
-    # If 8-hour AQI is >= 301, force fallback to 1-hour
-    if sub_8h > 300:
-        o3_sub = sub_1h if not math.isnan(sub_1h) else 300.0
-    else:
-        # Return max of available sub-indices
-        o3_valid = [v for v in (sub_1h, sub_8h) if not math.isnan(v)]
-        o3_sub = max(o3_valid) if o3_valid else float("nan")
-
-    if not math.isnan(pm25_ug):
-        sub_indices.append(_aqi_from_breakpoints(pm25_ug, TAQI_PM25_BP, TAQI_INDEX))
-    if not math.isnan(pm10_ug):
-        sub_indices.append(_aqi_from_breakpoints(pm10_ug, TAQI_PM10_BP, TAQI_INDEX))
-    if not math.isnan(o3_sub):
-        sub_indices.append(o3_sub)
-    if not math.isnan(no2_ppb):
-        sub_indices.append(_aqi_from_breakpoints(no2_ppb, TAQI_NO2_BP, TAQI_INDEX))
-    if not math.isnan(so2_ppb):
-        sub_indices.append(_aqi_from_breakpoints(so2_ppb, TAQI_SO2_BP, TAQI_INDEX))
-    if not math.isnan(co_ppb):
-        sub_indices.append(_aqi_from_breakpoints(co_ppb, TAQI_CO_BP, TAQI_INDEX))
-
-    valid = [v for v in sub_indices if not math.isnan(v)]
-    return float(max(valid)) if valid else float("nan")
-
-
-# ---------------------------------------------------------------------------
 # Vietnam VN_AQI
 # ---------------------------------------------------------------------------
 
@@ -1058,7 +986,6 @@ AQI_SYSTEM_MAP = {
     "id": "ISPU",
     "cn": "CHINA_AQI",
     "my": "API",
-    "tw": "TAQI",
     "vn": "VN_AQI",
 }
 
@@ -1107,10 +1034,6 @@ def compute_aqi_for_unit_system(
             so2_ppb,
             co_ppb,
             co_ppb,
-        )
-    elif system == "TAQI":
-        return compute_taiwan_aqi(
-            pm25_ug, pm10_ug, o3_ppb, o3_ppb, no2_ppb, so2_ppb, co_ppb
         )
     elif system == "VN_AQI":
         return compute_vn_aqi(
@@ -1237,16 +1160,6 @@ def compute_aqi_array(
         no2_calc = np.round(no2_v, 0)
         so2_calc = np.round(so2_v, 0)
         co_calc = np.round(co_v, 0)
-    elif system == "TAQI":
-        # Taiwan AQI uses 24-hour rolling averages for PM2.5, PM10, 8-hour for O3, and 1-hour for NO2, SO2, CO
-        # For PM2.5, round to 1 decimal place; for PM10, O3, NO2, SO2, CO round to whole numbers
-        pm25_calc = np.round(rolling_mean(pm25_v, window=24), 1)
-        pm10_calc = np.round(rolling_mean(pm10_v, window=24), 0)
-        o3_8h_calc = np.round(rolling_mean(o3_v, window=8), 0)
-        o3_calc = np.round(rolling_mean(o3_v, window=1), 0)
-        no2_calc = np.round(rolling_mean(no2_v, window=24), 0)
-        so2_calc = np.round(rolling_mean(so2_v, window=24), 0)
-        co_calc = np.round(rolling_mean(co_v, window=24), 0)
     elif system == "VN_AQI":
         # Vietnam AQI uses nowcast for PM2.5, PM10, 8-hour for O3, and 1-hour for NO2, SO2, CO
         # For all pollutants, round to whole numbers
@@ -1283,16 +1196,6 @@ def compute_aqi_array(
                 no2_1h_ppb=float(no2_calc[i]),
                 so2_1h_ppb=float(so2_calc[i]),
                 co_1h_ppb=float(co_calc[i]),
-            )
-        elif system == "TAQI":
-            result[i] = compute_taiwan_aqi(
-                pm25_ug=float(pm25_calc[i]),
-                pm10_ug=float(pm10_calc[i]),
-                o3_8h_ppb=float(o3_8h_calc[i]),
-                o3_1h_ppb=float(o3_calc[i]),
-                no2_ppb=float(no2_calc[i]),
-                so2_ppb=float(so2_calc[i]),
-                co_ppb=float(co_calc[i]),
             )
         elif system == "VN_AQI":
             result[i] = compute_vn_aqi(

--- a/API/constants/aqi_const.py
+++ b/API/constants/aqi_const.py
@@ -1079,7 +1079,7 @@ def compute_aqi_for_unit_system(
     system = AQI_SYSTEM_MAP.get(unit_system, "EPA")
     if system == "EPA":
         return compute_epa_aqi(
-            pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb, so2_ppb, co_ppb
+            pm25_ug, pm10_ug, o3_ppb, o3_ppb, no2_ppb, so2_ppb, so2_ppb, co_ppb
         )
     elif system == "AQHI":
         return compute_aqhi(pm25_ug, o3_ppb, no2_ppb)
@@ -1283,6 +1283,16 @@ def compute_aqi_array(
                 no2_1h_ppb=float(no2_calc[i]),
                 so2_1h_ppb=float(so2_calc[i]),
                 co_1h_ppb=float(co_calc[i]),
+            )
+        elif system == "TAQI":
+            result[i] = compute_taiwan_aqi(
+                pm25_ug=float(pm25_calc[i]),
+                pm10_ug=float(pm10_calc[i]),
+                o3_8h_ppb=float(o3_8h_calc[i]),
+                o3_1h_ppb=float(o3_calc[i]),
+                no2_ppb=float(no2_calc[i]),
+                so2_ppb=float(so2_calc[i]),
+                co_ppb=float(co_calc[i]),
             )
         elif system == "VN_AQI":
             result[i] = compute_vn_aqi(

--- a/API/constants/aqi_const.py
+++ b/API/constants/aqi_const.py
@@ -6,6 +6,12 @@ Supports three AQI systems:
   - EU CAQI     (unit_system="si")
   - UK DAQI      (unit_system="uk")
   - Hong Kong AQHI (aqisystem="hk")
+  - Israel AQHI (aqisystem="il")
+  - Indonesia ISPU (aqisystem="id")
+  - China AQI (aqisystem="cn")
+  - Malaysia API (aqisystem="my")
+  - Taiwan AQI (aqisystem="tw")
+  - Vietnam VN_AQI (aqisystem="vn")
 
 All input concentrations use the model-native units:
   - PM2.5, PM10: µg/m³
@@ -18,6 +24,12 @@ References:
     - EU CAQI: https://www.airqualitynow.eu/about_indices_definition.php
     - UK DAQI: https://aqihub.info/indices/uk
     - Hong Kong AQHI: https://www.aqhi.gov.hk/en.html
+    - Israel AQI: https://aqihub.info/indices/israel
+    - Indonesia ISPU: https://aqihub.info/indices/indonesia
+    - China AQI: https://aqihub.info/indices/china
+    - Malaysia API: https://aqihub.info/indices/malaysia
+    - Taiwan AQI: https://aqihub.info/indices/taiwan
+    - Vietnam VN_AQI: https://aqihub.info/indices/vietnam
 """
 
 from __future__ import annotations
@@ -194,6 +206,85 @@ DAQI_INDEX = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]  # DAQI 1–10
 # ---------------------------------------------------------------------------
 # The Irish AQIH uses the same breakpoints as the UK DAQI, but the SO2 breakpoints are slightly different. The AQIH SO2 breakpoints are:
 AQIH_SO2_BP = [0, 30, 60, 90, 120, 150, 180, 237, 296, 355]  # µg/m³
+
+# ---------------------------------------------------------------------------
+# Israel AQI breakpoints (µg/m³ for all species except CO, which is in mg/m³)
+# Reference: https://aqihub.info/indices/israel
+# ---------------------------------------------------------------------------
+IAQI_PM25_BP = [0, 18.5, 37, 84, 130, 165, 200]
+IAQI_PM10_BP = [0, 65, 129, 215, 300, 355, 430]
+IAQI_O3_BP = [0, 35, 70, 97, 117, 155, 188]  # µg/m³
+IAQI_NO2_BP = [0, 53, 105, 160, 213, 260, 316]  # µg/m³
+IAQI_SO2_BP = [0, 67, 133, 163, 191, 253, 303]  # µg/m³
+IAQI_CO_BP = [0, 26, 51, 78, 104, 130, 156]  # mg/m³
+IAQI_INDEX = [0, 50, 100, 200, 300, 400, 500]  # Israel 0–500
+
+# ---------------------------------------------------------------------------
+# Indonesia ISPU breakpoints (µg/m³ for all species)
+# Reference: https://aqihub.info/indices/indonesia
+# ---------------------------------------------------------------------------
+ISPU_PM25_BP = [0, 15.5, 55.4, 150.4, 250.4, 500]
+ISPU_PM10_BP = [0, 50, 150, 350, 420, 500]
+ISPU_O3_BP = [0, 120, 235, 400, 800, 1000]  # µg/m³
+ISPU_NO2_BP = [0, 80, 200, 1130, 2260, 3000]  # µg/m³
+ISPU_SO2_BP = [0, 52, 180, 400, 800, 1200]  # µg/m³
+ISPU_CO_BP = [0, 4000, 8000, 15000, 30000, 45000]  # µg/m³
+ISPU_INDEX = [0, 50, 100, 200, 300, 500]  # ISPU 0–500
+
+# ---------------------------------------------------------------------------
+# China AQI breakpoints (µg/m³ for all species except CO, which is in mg/m³)
+# Reference: https://aqihub.info/indices/china
+# ---------------------------------------------------------------------------
+# Master IAQI Scale (0 to 500)
+CHINA_AQI_INDEX = [0, 50, 100, 150, 200, 300, 400, 500]
+CHINA_PM25_24H_BP = [0.0, 35.0, 75.0, 115.0, 150.0, 250.0, 350.0, 500.0]
+CHINA_PM10_24H_BP = [0.0, 50.0, 150.0, 250.0, 350.0, 420.0, 500.0, 600.0]
+CHINA_NO2_1H_BP = [0.0, 100.0, 200.0, 700.0, 1200.0, 2340.0, 3090.0, 3840.0]
+CHINA_NO2_24H_BP = [0.0, 40.0, 80.0, 180.0, 280.0, 565.0, 750.0, 940.0]
+CHINA_O3_1H_BP = [0.0, 160.0, 200.0, 300.0, 400.0, 800.0, 1000.0, 1200.0]
+CHINA_O3_8H_BP = [0.0, 100.0, 160.0, 215.0, 265.0, 800.0]
+CHINA_SO2_1H_BP = [0.0, 150.0, 500.0, 650.0, 800.0]
+CHINA_SO2_24H_BP = [0.0, 50.0, 150.0, 475.0, 800.0, 1600.0, 2100.0, 2620.0]
+CHINA_CO_1H_BP = [0.0, 5.0, 10.0, 35.0, 60.0, 90.0, 120.0, 150.0]
+CHINA_CO_24H_BP = [0.0, 2.0, 4.0, 14.0, 24.0, 36.0, 48.0, 60.0]
+
+# ---------------------------------------------------------------------------
+# Malaysia API breakpoints (µg/m³ for PM and ppb for gases)
+# Reference: https://aqihub.info/indices/malaysia
+# ---------------------------------------------------------------------------
+API_PM25_BP = [0, 103, 153, 203, 253, 508]
+API_PM10_BP = [0, 190, 240, 290, 340, 682]
+API_O3_BP = [0, 80, 134, 187, 240, 482]
+API_NO2_BP = [0, 106, 178, 249, 320, 642]
+API_SO2_BP = [0, 134, 172, 210, 249, 500]
+API_CO_BP = [0, 3000, 4000, 5000, 6000, 12000]
+API_INDEX = [0, 50, 100, 200, 300, 500]  # API 0–500
+
+# ---------------------------------------------------------------------------
+# Taiwan AQI breakpoints (µg/m³ for PM and ppb for NO2 and SO2 and ppm for CO and O3)
+# Reference: https://aqihub.info/indices/taiwan
+# ---------------------------------------------------------------------------
+TAQI_PM25_BP = [0, 15.4, 35.4, 54.4, 150.4, 250.4, 500.4]
+TAQI_PM10_BP = [0, 50, 100, 254, 354, 424, 604]
+TAQI_O3_1H_BP = [0, 0, 124, 164, 204, 404, 604]
+TAQI_O3_8H_BP = [0, 54, 70, 85, 105, 200, 200]
+TAQI_NO2_BP = [0, 30, 100, 360, 649, 1249, 2049]
+TAQI_SO2_BP = [0, 20, 75, 185, 304, 604, 605]
+TAQI_CO_BP = [0, 4400, 9400, 12400, 15400, 30400, 60400]
+TAQI_INDEX = [0, 50, 100, 150, 200, 300, 500]  # Taiwan 0–500
+
+# ---------------------------------------------------------------------------
+# Vietnam VN_AQI breakpoints (µg/m³ for all species)
+# Reference: https://aqihub.info/indices/vietnam
+# ---------------------------------------------------------------------------
+VNAQI_PM25_BP = [0, 25, 80, 150, 250, 350, 500]
+VNAQI_PM10_BP = [0, 50, 250, 350, 430, 500, 600]
+VNAQI_O3_1H_BP = [0, 160, 300, 400, 800, 1000, 1200]
+VNAQI_O3_8H_BP = [0, 100, 170, 210, 400, 400, 400]
+VNAQI_NO2_BP = [0, 100, 700, 1200, 2350, 3100, 3850]
+VNAQI_SO2_BP = [0, 125, 550, 800, 1600, 2100, 2630]
+VNAQI_CO_BP = [0, 10000, 45000, 60000, 90000, 120000, 150000]
+VNAQI_INDEX = [0, 50, 100, 150, 200, 300, 500]  # Vietnam 0–500
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -528,6 +619,394 @@ def compute_aqih(
     valid = [v for v in sub_indices if not math.isnan(v)]
     return float(max(valid)) if valid else float("nan")
 
+
+# ---------------------------------------------------------------------------
+# Israel IAQI
+# ---------------------------------------------------------------------------
+
+
+def compute_iaqi(
+    pm25_ug: float = float("nan"),
+    pm10_ug: float = float("nan"),
+    o3_ppb: float = float("nan"),
+    no2_ppb: float = float("nan"),
+    so2_ppb: float = float("nan"),
+    co_ppb: float = float("nan"),
+) -> float:
+    """Compute the Israeli Air Quality Index (IAQI).
+
+    Returns the maximum sub-index across available pollutants.
+    """
+
+    # Convert gases from ppb to µg/m³
+    o3_ug = o3_ppb * PPB_O3_TO_UG_M3 if not math.isnan(o3_ppb) else float("nan")
+    no2_ug = no2_ppb * PPB_NO2_TO_UG_M3 if not math.isnan(no2_ppb) else float("nan")
+    so2_ug = so2_ppb * PPB_SO2_TO_UG_M3 if not math.isnan(so2_ppb) else float("nan")
+    co_mg = (
+        (co_ppb * PPB_CO_TO_UG_M3) / 1000 if not math.isnan(co_ppb) else float("nan")
+    )
+
+    sub_indices = []
+    if not math.isnan(pm25_ug):
+        sub_indices.append(_aqi_from_breakpoints(pm25_ug, IAQI_PM25_BP, IAQI_INDEX))
+    if not math.isnan(pm10_ug):
+        sub_indices.append(_aqi_from_breakpoints(pm10_ug, IAQI_PM10_BP, IAQI_INDEX))
+    if not math.isnan(o3_ug):
+        sub_indices.append(_aqi_from_breakpoints(o3_ug, IAQI_O3_BP, IAQI_INDEX))
+    if not math.isnan(no2_ug):
+        sub_indices.append(_aqi_from_breakpoints(no2_ug, IAQI_NO2_BP, IAQI_INDEX))
+    if not math.isnan(so2_ug):
+        sub_indices.append(_aqi_from_breakpoints(so2_ug, IAQI_SO2_BP, IAQI_INDEX))
+    if not math.isnan(co_mg):
+        sub_indices.append(_aqi_from_breakpoints(co_mg, IAQI_CO_BP, IAQI_INDEX))
+
+    valid = [v for v in sub_indices if not math.isnan(v)]
+    return 100 - float(max(valid)) if valid else float("nan")
+
+
+# ---------------------------------------------------------------------------
+# Indonesia ISPU
+# ---------------------------------------------------------------------------
+
+
+def compute_ispu(
+    pm25_ug: float = float("nan"),
+    pm10_ug: float = float("nan"),
+    o3_ppb: float = float("nan"),
+    no2_ppb: float = float("nan"),
+    so2_ppb: float = float("nan"),
+    co_ppb: float = float("nan"),
+) -> float:
+    """Compute the Indonesian Air Quality Index (ISPU).
+
+    Returns the maximum sub-index across available pollutants.
+    """
+
+    # Convert gases from ppb to µg/m³
+    o3_ug = o3_ppb * PPB_O3_TO_UG_M3 if not math.isnan(o3_ppb) else float("nan")
+    no2_ug = no2_ppb * PPB_NO2_TO_UG_M3 if not math.isnan(no2_ppb) else float("nan")
+    so2_ug = so2_ppb * PPB_SO2_TO_UG_M3 if not math.isnan(so2_ppb) else float("nan")
+    co_ug = co_ppb * PPB_CO_TO_UG_M3 if not math.isnan(co_ppb) else float("nan")
+
+    sub_indices = []
+    if not math.isnan(pm25_ug):
+        sub_indices.append(_aqi_from_breakpoints(pm25_ug, ISPU_PM25_BP, ISPU_INDEX))
+    if not math.isnan(pm10_ug):
+        sub_indices.append(_aqi_from_breakpoints(pm10_ug, ISPU_PM10_BP, ISPU_INDEX))
+    if not math.isnan(o3_ug):
+        sub_indices.append(_aqi_from_breakpoints(o3_ug, ISPU_O3_BP, ISPU_INDEX))
+    if not math.isnan(no2_ug):
+        sub_indices.append(_aqi_from_breakpoints(no2_ug, ISPU_NO2_BP, ISPU_INDEX))
+    if not math.isnan(so2_ug):
+        sub_indices.append(_aqi_from_breakpoints(so2_ug, ISPU_SO2_BP, ISPU_INDEX))
+    if not math.isnan(co_ug):
+        sub_indices.append(_aqi_from_breakpoints(co_ug, ISPU_CO_BP, ISPU_INDEX))
+
+    valid = [v for v in sub_indices if not math.isnan(v)]
+    return float(max(valid)) if valid else float("nan")
+
+
+# ---------------------------------------------------------------------------
+# China AQI
+# ---------------------------------------------------------------------------
+
+
+def compute_china_aqi(
+    pm25_ug: float = float("nan"),
+    pm10_ug: float = float("nan"),
+    o3_8h_ppb: float = float("nan"),
+    o3_1h_ppb: float = float("nan"),
+    no2_1h_ppb: float = float("nan"),
+    no2_24h_ppb: float = float("nan"),
+    so2_1h_ppb: float = float("nan"),
+    so2_24h_ppb: float = float("nan"),
+    co_1h_ppb: float = float("nan"),
+    co_24h_ppb: float = float("nan"),
+) -> float:
+    """Compute China AQI as the maximum sub-index across available pollutants."""
+
+    def safe_max(*vals):
+        """Returns the maximum of valid numeric scores, or NaN if all are invalid."""
+        valid = [v for v in vals if v is not None and not math.isnan(v)]
+        return max(valid) if valid else float("nan")
+
+    sub_indices = []
+
+    # Convert gases from ppb to µg/m³
+    o3_1h_ug = (
+        o3_1h_ppb * PPB_O3_TO_UG_M3 if not math.isnan(o3_1h_ppb) else float("nan")
+    )
+    o3_8h_ug = (
+        o3_8h_ppb * PPB_O3_TO_UG_M3 if not math.isnan(o3_8h_ppb) else float("nan")
+    )
+    no2_1h_ug = (
+        no2_1h_ppb * PPB_NO2_TO_UG_M3 if not math.isnan(no2_1h_ppb) else float("nan")
+    )
+    no2_24h_ug = (
+        no2_24h_ppb * PPB_NO2_TO_UG_M3 if not math.isnan(no2_24h_ppb) else float("nan")
+    )
+    so2_1h_ug = (
+        so2_1h_ppb * PPB_SO2_TO_UG_M3 if not math.isnan(so2_1h_ppb) else float("nan")
+    )
+    so2_24h_ug = (
+        so2_24h_ppb * PPB_SO2_TO_UG_M3 if not math.isnan(so2_24h_ppb) else float("nan")
+    )
+    co_1h_mg = (
+        (co_1h_ppb * PPB_CO_TO_UG_M3) / 1000
+        if not math.isnan(co_1h_ppb)
+        else float("nan")
+    )
+    co_24h_mg = (
+        (co_24h_ppb * PPB_CO_TO_UG_M3) / 1000
+        if not math.isnan(co_24h_ppb)
+        else float("nan")
+    )
+
+    o3_sub = float("nan")
+    so2_sub = float("nan")
+    no2_sub = float("nan")
+    co_sub = float("nan")
+
+    # --- 1. OZONE (O3) ---
+    o3_1h_sub = float("nan")
+    o3_8h_sub = float("nan")
+
+    if not math.isnan(o3_1h_ug):
+        o3_1h_sub = _aqi_from_breakpoints(o3_1h_ug, CHINA_O3_1H_BP, CHINA_AQI_INDEX)
+
+    if not math.isnan(o3_8h_ug):
+        # HJ 633: If O3 8-hr > 800, 8-hr calculation is invalidated in favor of 1-hr.
+        # If 1-hr is unavailable, clamp at 800 ug/m3.
+        if o3_8h_ug <= 800:
+            o3_8h_sub = _aqi_from_breakpoints(o3_8h_ug, CHINA_O3_8H_BP, CHINA_AQI_INDEX)
+        elif math.isnan(o3_1h_sub):
+            o3_8h_sub = _aqi_from_breakpoints(800.0, CHINA_O3_8H_BP, CHINA_AQI_INDEX)
+
+    o3_sub = safe_max(o3_1h_sub, o3_8h_sub)
+
+    # --- 2. SULFUR DIOXIDE (SO2) ---
+    so2_1h_sub = float("nan")
+    so2_24h_sub = float("nan")
+
+    if not math.isnan(so2_24h_ug):
+        so2_24h_sub = _aqi_from_breakpoints(
+            so2_24h_ug, CHINA_SO2_24H_BP, CHINA_AQI_INDEX
+        )
+
+    if not math.isnan(so2_1h_ug):
+        # HJ 633: SO2 1-hr table only goes up to IAQI 200 (800 ug/m3).
+        # For concentrations > 800, rely on 24-hr average. If 24-hr is missing, cap at 200.
+        if so2_1h_ug <= 800:
+            so2_1h_sub = _aqi_from_breakpoints(
+                so2_1h_ug, CHINA_SO2_1H_BP, CHINA_AQI_INDEX
+            )
+        elif math.isnan(so2_24h_sub):
+            so2_1h_sub = 200.0  # Cap at max available 1-hr IAQI
+
+    so2_sub = safe_max(so2_1h_sub, so2_24h_sub)
+
+    # --- 3. NITROGEN DIOXIDE (NO2) ---
+    no2_1h_sub = float("nan")
+    no2_24h_sub = float("nan")
+
+    if not math.isnan(no2_1h_ug):
+        no2_1h_sub = _aqi_from_breakpoints(no2_1h_ug, CHINA_NO2_1H_BP, CHINA_AQI_INDEX)
+
+    if not math.isnan(no2_24h_ug):
+        no2_24h_sub = _aqi_from_breakpoints(
+            no2_24h_ug, CHINA_NO2_24H_BP, CHINA_AQI_INDEX
+        )
+
+    no2_sub = safe_max(no2_1h_sub, no2_24h_sub)
+
+    # --- 4. CARBON MONOXIDE (CO) ---
+    co_1h_sub = float("nan")
+    co_24h_sub = float("nan")
+
+    if not math.isnan(co_1h_mg):
+        co_1h_sub = _aqi_from_breakpoints(co_1h_mg, CHINA_CO_1H_BP, CHINA_AQI_INDEX)
+
+    if not math.isnan(co_24h_mg):
+        co_24h_sub = _aqi_from_breakpoints(co_24h_mg, CHINA_CO_24H_BP, CHINA_AQI_INDEX)
+
+    co_sub = safe_max(co_1h_sub, co_24h_sub)
+
+    if not math.isnan(pm25_ug):
+        sub_indices.append(
+            _aqi_from_breakpoints(pm25_ug, CHINA_PM25_24H_BP, CHINA_AQI_INDEX)
+        )
+    if not math.isnan(pm10_ug):
+        sub_indices.append(
+            _aqi_from_breakpoints(pm10_ug, CHINA_PM10_24H_BP, CHINA_AQI_INDEX)
+        )
+    if not math.isnan(o3_sub):
+        sub_indices.append(o3_sub)
+    if not math.isnan(no2_sub):
+        sub_indices.append(no2_sub)
+    if not math.isnan(so2_sub):
+        sub_indices.append(so2_sub)
+    if not math.isnan(co_sub):
+        sub_indices.append(co_sub)
+
+    valid = [v for v in sub_indices if not math.isnan(v)]
+    return float(max(valid)) if valid else float("nan")
+
+
+# ---------------------------------------------------------------------------
+# Malaysia API
+# ---------------------------------------------------------------------------
+
+
+def compute_api(
+    pm25_ug: float = float("nan"),
+    pm10_ug: float = float("nan"),
+    o3_ppb: float = float("nan"),
+    no2_ppb: float = float("nan"),
+    so2_ppb: float = float("nan"),
+    co_ppb: float = float("nan"),
+) -> float:
+    """Compute the Malaysian Air Quality Index (API).
+
+    Returns the maximum sub-index across available pollutants.
+    """
+
+    sub_indices = []
+    if not math.isnan(pm25_ug):
+        sub_indices.append(_aqi_from_breakpoints(pm25_ug, API_PM25_BP, API_INDEX))
+    if not math.isnan(pm10_ug):
+        sub_indices.append(_aqi_from_breakpoints(pm10_ug, API_PM10_BP, API_INDEX))
+    if not math.isnan(o3_ppb):
+        sub_indices.append(_aqi_from_breakpoints(o3_ppb, API_O3_BP, API_INDEX))
+    if not math.isnan(no2_ppb):
+        sub_indices.append(_aqi_from_breakpoints(no2_ppb, API_NO2_BP, API_INDEX))
+    if not math.isnan(so2_ppb):
+        sub_indices.append(_aqi_from_breakpoints(so2_ppb, API_SO2_BP, API_INDEX))
+    if not math.isnan(co_ppb):
+        sub_indices.append(_aqi_from_breakpoints(co_ppb, API_CO_BP, API_INDEX))
+
+    valid = [v for v in sub_indices if not math.isnan(v)]
+    return float(max(valid)) if valid else float("nan")
+
+
+# ---------------------------------------------------------------------------
+# Taiwan AQI
+# ---------------------------------------------------------------------------
+
+
+def compute_taiwan_aqi(
+    pm25_ug: float = float("nan"),
+    pm10_ug: float = float("nan"),
+    o3_8h_ppb: float = float("nan"),
+    o3_1h_ppb: float = float("nan"),
+    no2_ppb: float = float("nan"),
+    so2_ppb: float = float("nan"),
+    co_ppb: float = float("nan"),
+) -> float:
+    """Compute Taiwan AQI as the maximum sub-index across available pollutants."""
+    sub_indices = []
+
+    o3_sub = float("nan")
+
+    # 1. Calculate 8-hour sub-index (valid up to AQI 300)
+    if not math.isnan(o3_8h_ppb):
+        # 8-hr table caps at 200 ppb (AQI 300)
+        sub_8h = _aqi_from_breakpoints(o3_8h_ppb, TAQI_O3_8H_BP, TAQI_INDEX)
+
+    # 2. Calculate 1-hour sub-index (only evaluated if >= 125 ppb / AQI >= 101)
+    if not math.isnan(o3_1h_ppb) and o3_1h_ppb >= 125.0:
+        sub_1h = _aqi_from_breakpoints(o3_1h_ppb, TAQI_O3_1H_BP, TAQI_INDEX)
+
+    # 3. Handle threshold boundaries
+    # If 8-hour AQI is >= 301, force fallback to 1-hour
+    if sub_8h > 300:
+        o3_sub = sub_1h if not math.isnan(sub_1h) else 300.0
+    else:
+        # Return max of available sub-indices
+        o3_valid = [v for v in (sub_1h, sub_8h) if not math.isnan(v)]
+        o3_sub = max(o3_valid) if o3_valid else float("nan")
+
+    if not math.isnan(pm25_ug):
+        sub_indices.append(_aqi_from_breakpoints(pm25_ug, TAQI_PM25_BP, TAQI_INDEX))
+    if not math.isnan(pm10_ug):
+        sub_indices.append(_aqi_from_breakpoints(pm10_ug, TAQI_PM10_BP, TAQI_INDEX))
+    if not math.isnan(o3_sub):
+        sub_indices.append(o3_sub)
+    if not math.isnan(no2_ppb):
+        sub_indices.append(_aqi_from_breakpoints(no2_ppb, TAQI_NO2_BP, TAQI_INDEX))
+    if not math.isnan(so2_ppb):
+        sub_indices.append(_aqi_from_breakpoints(so2_ppb, TAQI_SO2_BP, TAQI_INDEX))
+    if not math.isnan(co_ppb):
+        sub_indices.append(_aqi_from_breakpoints(co_ppb, TAQI_CO_BP, TAQI_INDEX))
+
+    valid = [v for v in sub_indices if not math.isnan(v)]
+    return float(max(valid)) if valid else float("nan")
+
+
+# ---------------------------------------------------------------------------
+# Vietnam VN_AQI
+# ---------------------------------------------------------------------------
+
+
+def compute_vn_aqi(
+    pm25_ug: float = float("nan"),
+    pm10_ug: float = float("nan"),
+    o3_8h_ppb: float = float("nan"),
+    o3_1h_ppb: float = float("nan"),
+    no2_ppb: float = float("nan"),
+    so2_ppb: float = float("nan"),
+    co_ppb: float = float("nan"),
+) -> float:
+    """Compute Vietnam VN_AQI as the maximum sub-index across available pollutants."""
+    sub_indices = []
+
+    # Convert gases from ppb to µg/m³
+    o3_1h_ug = (
+        o3_1h_ppb * PPB_O3_TO_UG_M3 if not math.isnan(o3_1h_ppb) else float("nan")
+    )
+    o3_8h_ug = (
+        o3_8h_ppb * PPB_O3_TO_UG_M3 if not math.isnan(o3_8h_ppb) else float("nan")
+    )
+    no2_ug = no2_ppb * PPB_NO2_TO_UG_M3 if not math.isnan(no2_ppb) else float("nan")
+    so2_ug = so2_ppb * PPB_SO2_TO_UG_M3 if not math.isnan(so2_ppb) else float("nan")
+    co_ug = co_ppb * PPB_CO_TO_UG_M3 if not math.isnan(co_ppb) else float("nan")
+
+    o3_sub = float("nan")
+
+    # 1. Calculate 8-hour sub-index (valid up to AQI 200)
+    if not math.isnan(o3_8h_ug):
+        # 8-hr table caps at 400 µg/m³ (AQI 200)
+        sub_8h = _aqi_from_breakpoints(o3_8h_ug, VNAQI_O3_8H_BP, VNAQI_INDEX)
+
+    # 2. Calculate 1-hour sub-index
+    if not math.isnan(o3_1h_ug):
+        sub_1h = _aqi_from_breakpoints(o3_1h_ug, VNAQI_O3_1H_BP, VNAQI_INDEX)
+
+    # 3. Handle threshold boundaries
+    # If 8-hour AQI is >= 201, force fallback to 1-hour
+    if sub_8h > 200:
+        o3_sub = sub_1h if not math.isnan(sub_1h) else 200.0
+    else:
+        # Return max of available sub-indices
+        o3_valid = [v for v in (sub_1h, sub_8h) if not math.isnan(v)]
+        o3_sub = max(o3_valid) if o3_valid else float("nan")
+
+    if not math.isnan(pm25_ug):
+        sub_indices.append(_aqi_from_breakpoints(pm25_ug, VNAQI_PM25_BP, VNAQI_INDEX))
+    if not math.isnan(pm10_ug):
+        sub_indices.append(_aqi_from_breakpoints(pm10_ug, VNAQI_PM10_BP, VNAQI_INDEX))
+    if not math.isnan(o3_sub):
+        sub_indices.append(o3_sub)
+    if not math.isnan(no2_ug):
+        sub_indices.append(_aqi_from_breakpoints(no2_ug, VNAQI_NO2_BP, VNAQI_INDEX))
+    if not math.isnan(so2_ug):
+        sub_indices.append(_aqi_from_breakpoints(so2_ug, VNAQI_SO2_BP, VNAQI_INDEX))
+    if not math.isnan(co_ug):
+        sub_indices.append(_aqi_from_breakpoints(co_ug, VNAQI_CO_BP, VNAQI_INDEX))
+
+    valid = [v for v in sub_indices if not math.isnan(v)]
+    return float(max(valid)) if valid else float("nan")
+
+
 # ---------------------------------------------------------------------------
 # Unified dispatcher
 # ---------------------------------------------------------------------------
@@ -540,6 +1019,12 @@ AQI_SYSTEM_MAP = {
     "si": "CAQI",
     "hk": "HK_AQHI",
     "ie": "AQIH",
+    "il": "IAQI",
+    "id": "ISPU",
+    "cn": "CHINA_AQI",
+    "my": "API",
+    "tw": "TAQI",
+    "vn": "VN_AQI",
 }
 
 
@@ -567,6 +1052,10 @@ def compute_aqi_for_unit_system(
         return compute_hk_aqhi(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb)
     elif system == "AQIH":
         return compute_aqih(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb)
+    elif system == "ISPU":
+        return compute_ispu(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb, co_ppb)
+    elif system == "API":
+        return compute_api(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb, co_ppb)
     else:  # EAQI
         return compute_caqi(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb)
 
@@ -657,6 +1146,56 @@ def compute_aqi_array(
         o3_calc = rolling_mean(o3_v, window=3)
         no2_calc = rolling_mean(no2_v, window=3)
         so2_calc = rolling_mean(so2_v, window=3)
+    elif system == "IAQI":
+        # Israel IAQA uses 24-hour rolling averages for PM2.5 and PM10, 8-hour for O3 and 1-hour for NO2, SO2, CO
+        pm25_calc = rolling_mean(pm25_v, window=24)
+        pm10_calc = rolling_mean(pm10_v, window=24)
+        o3_calc = rolling_mean(o3_v, window=8)
+    elif system == "ISPU":
+        # Indonesia ISPU uses 24-hour rolling averages
+        # PM2.5 is rounded to 1 decimal place, PM10, O3, NO2, SO2, CO are rounded to whole numbers
+        pm25_calc = round(rolling_mean(pm25_v, window=24), 1)
+        pm10_calc = round(rolling_mean(pm10_v, window=24), 0)
+        o3_calc = round(rolling_mean(o3_v, window=24), 0)
+        co_calc = round(rolling_mean(co_v, window=24), 0)
+        so2_calc = round(rolling_mean(so2_v, window=24), 0)
+        no2_calc = round(rolling_mean(no2_v, window=24), 0)
+    elif system == "CHINA_AQI":
+        # China AQI uses 24-hour rolling averages for PM2.5, PM10, NO2, SO2, CO and 8-hour rolling average for O3
+        pm25_calc = rolling_mean(pm25_v, window=24)
+        pm10_calc = rolling_mean(pm10_v, window=24)
+        o3_8h_calc = rolling_mean(o3_v, window=8)
+        no2_24_calc = rolling_mean(no2_v, window=24)
+        so2_24_calc = rolling_mean(so2_v, window=24)
+        co_24_calc = rolling_mean(co_v, window=24)
+    elif system == "API":
+        # Malayia rounds everything to nearest whole number
+        pm25_calc = round(pm25_v, 0)
+        pm10_calc = round(pm10_v, 0)
+        o3_calc = round(o3_v, 0)
+        no2_calc = round(no2_v, 0)
+        so2_calc = round(so2_v, 0)
+        co_calc = round(co_v, 0)
+    elif system == "TAQI":
+        # Taiwan AQI uses 24-hour rolling averages for PM2.5, PM10, 8-hour for O3, and 1-hour for NO2, SO2, CO
+        # For PM2.5, round to 1 decimal place; for PM10, O3, NO2, SO2, CO round to whole numbers
+        pm25_calc = round(rolling_mean(pm25_v, window=24), 1)
+        pm10_calc = round(rolling_mean(pm10_v, window=24), 0)
+        o3_8h_calc = round(rolling_mean(o3_v, window=8), 0)
+        o3_1h_calc = round(rolling_mean(o3_v, window=1), 0)
+        no2_calc = round(rolling_mean(no2_v, window=24), 0)
+        so2_calc = round(rolling_mean(so2_v, window=24), 0)
+        co_calc = round(rolling_mean(co_v, window=24), 0)
+    elif system == "VN_AQI":
+        # Vietnam AQI uses nowcast for PM2.5, PM10, 8-hour for O3, and 1-hour for NO2, SO2, CO
+        # For all pollutants, round to whole numbers
+        pm25_calc = round(nowcast_pm(pm25_v), 0)
+        pm10_calc = round(nowcast_pm(pm10_v), 0)
+        o3_8h_calc = round(rolling_mean(o3_v, window=8), 0)
+        o3_calc = round(o3_v, 0)
+        no2_calc = round(no2_v, 0)
+        so2_calc = round(so2_v, 0)
+        co_calc = round(co_v, 0)
 
     result = np.full(n, np.nan, dtype=np.float32)
     for i in range(n):
@@ -666,6 +1205,29 @@ def compute_aqi_array(
                 pm10_ug=float(pm10_calc[i]),
                 o3_8h_ppb=float(o3_calc[i]),
                 o3_1h_ppb=float(o3_1h_calc[i]),
+                no2_ppb=float(no2_calc[i]),
+                so2_ppb=float(so2_calc[i]),
+                co_ppb=float(co_calc[i]),
+            )
+        elif system == "CHINA_AQI":
+            result[i] = compute_china_aqi(
+                pm25_ug=float(pm25_calc[i]),
+                pm10_ug=float(pm10_calc[i]),
+                o3_8h_ppb=float(o3_8h_calc[i]),
+                o3_1h_ppb=float(o3_1h_calc[i]),
+                no2_24h_ppb=float(no2_24_calc[i]),
+                so2_24h_ppb=float(so2_24_calc[i]),
+                co_24h_ppb=float(co_24_calc[i]),
+                no2_1h_ppb=float(no2_calc[i]),
+                so2_1h_ppb=float(so2_calc[i]),
+                co_1h_ppb=float(co_calc[i]),
+            )
+        elif system == "VN_AQI":
+            result[i] = compute_vn_aqi(
+                pm25_ug=float(pm25_calc[i]),
+                pm10_ug=float(pm10_calc[i]),
+                o3_8h_ppb=float(o3_8h_calc[i]),
+                o3_1h_ppb=float(o3_calc[i]),
                 no2_ppb=float(no2_calc[i]),
                 so2_ppb=float(so2_calc[i]),
                 co_ppb=float(co_calc[i]),

--- a/API/constants/aqi_const.py
+++ b/API/constants/aqi_const.py
@@ -380,11 +380,11 @@ def compute_epa_aqi(
     if not math.isnan(so2_ppb):
         so2_sub = _epa_sub_index(so2_ppb, SO2_BP, SO2_AQI)
 
-    if (math.isnan(so2_sub) or so2_sub > 200) and not math.isnan(so2_24h_ppb):
+    use_24h = math.isnan(so2_ppb) or so2_ppb > SO2_BP[-1]
+    if use_24h and not math.isnan(so2_24h_ppb) and so2_24h_ppb >= SO2_24H_BP[0]:
         so2_24h_sub = _epa_sub_index(so2_24h_ppb, SO2_24H_BP, SO2_24H_AQI)
         if not math.isnan(so2_24h_sub):
-            so2_sub = so2_24h_sub
-
+            so2_sub = so2_24h_sub if math.isnan(so2_sub) else max(so2_sub, so2_24h_sub)
     if not math.isnan(pm25_ug):
         sub_indices.append(_epa_sub_index(pm25_ug, PM25_BP, PM25_AQI))
     if not math.isnan(pm10_ug):

--- a/API/constants/aqi_const.py
+++ b/API/constants/aqi_const.py
@@ -331,6 +331,64 @@ def compute_aqhi(
 
 
 # ---------------------------------------------------------------------------
+# Hong Kong AQHI
+# Formula: AQHI = %AR = %ARNO2 + %ARSO2 + %ARO3 + %ARPM
+# where beta coefficients are from the Hong Kong Environmental Protection Department.
+# C_i are 3-hour rolling averages in µg/m³ for PM2.5, PM10, SO2, NO2 and O3
+# Reference: https://www.aqhi.gov.hk/en.html
+# ---------------------------------------------------------------------------
+HK_AQHI_BETA_O3 = 0.0005116328  # Coefficient expects µg/m³
+HK_AQHI_BETA_NO2 = 0.0004462559  # Coefficient expects µg/m³
+HK_AQHI_BETA_PM25 = 0.0002180567  # Coefficient expects µg/m³
+HK_AQHI_BETA_PM10 = 0.0002821751  # Coefficient expects µg/m³
+HK_AQHI_BETA_SO2 = 0.0001393235  # Coefficient expects µg/m³
+HK_AR_BP = [1.89, 3.77, 5.65, 7.53, 9.42, 11.30, 12.92, 15.08, 17.23, 19.38]
+HK_AQHI = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+
+
+def compute_hk_aqhi(
+    pm25_ug: float = float("nan"),
+    pm10_ug: float = float("nan"),
+    o3_ppb: float = float("nan"),
+    no2_ppb: float = float("nan"),
+    so2_ppb: float = float("nan"),
+) -> float:
+    """Compute Hong Kong AQHI (1–10+ scale, capped at 11)."""
+    # Convert gases from ppb to µg/m³
+    o3 = o3_ppb * PPB_O3_TO_UG_M3 if not math.isnan(o3_ppb) else float("nan")
+    no2 = no2_ppb * PPB_NO2_TO_UG_M3 if not math.isnan(no2_ppb) else float("nan")
+    so2 = so2_ppb * PPB_SO2_TO_UG_M3 if not math.isnan(so2_ppb) else float("nan")
+    pm25 = pm25_ug if not math.isnan(pm25_ug) else float("nan")
+    pm10 = pm10_ug if not math.isnan(pm10_ug) else float("nan")
+
+    pm_ar = 0.0
+    count = 0
+    if not math.isnan(o3):
+        o3_ar = (math.exp(HK_AQHI_BETA_O3 * o3) - 1) * 100
+        count += 1
+    if not math.isnan(no2):
+        no2_ar = (math.exp(HK_AQHI_BETA_NO2 * no2) - 1) * 100
+        count += 1
+    if not math.isnan(so2):
+        so2_ar = (math.exp(HK_AQHI_BETA_SO2 * so2) - 1) * 100
+        count += 1
+    if not math.isnan(pm25):
+        pm25_ar = (math.exp(HK_AQHI_BETA_PM25 * pm25) - 1) * 100
+    if not math.isnan(pm10):
+        pm10_ar = (math.exp(HK_AQHI_BETA_PM10 * pm10) - 1) * 100
+
+    if not math.isnan(pm25) or not math.isnan(pm10):
+        pm_ar += max(pm25_ar, pm10_ar)
+        count += 1
+    if count == 0:
+        return float("nan")
+
+    ar_total = o3_ar + no2_ar + so2_ar + pm_ar
+    # Scale to familiar 1–10 range (10+ is "very high risk")
+    return _index_from_breakpoints(ar_total, HK_AR_BP, HK_AQHI)
+
+
+# ---------------------------------------------------------------------------
 # EU CAQI
 # ---------------------------------------------------------------------------
 

--- a/API/constants/aqi_const.py
+++ b/API/constants/aqi_const.py
@@ -1078,7 +1078,9 @@ def compute_aqi_for_unit_system(
     """
     system = AQI_SYSTEM_MAP.get(unit_system, "EPA")
     if system == "EPA":
-        return compute_epa_aqi(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb, so2_ppb, co_ppb)
+        return compute_epa_aqi(
+            pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb, so2_ppb, co_ppb
+        )
     elif system == "AQHI":
         return compute_aqhi(pm25_ug, o3_ppb, no2_ppb)
     elif system == "DAQI":

--- a/API/constants/aqi_const.py
+++ b/API/constants/aqi_const.py
@@ -6,6 +6,7 @@ Supports three AQI systems:
   - EU CAQI     (unit_system="si")
   - UK DAQI      (unit_system="uk")
   - Hong Kong AQHI (aqisystem="hk")
+  - Ireland AQIH (aqisystem="ie")
   - Israel AQHI (aqisystem="il")
   - Indonesia ISPU (aqisystem="id")
   - China AQI (aqisystem="cn")
@@ -24,6 +25,7 @@ References:
     - EU CAQI: https://www.airqualitynow.eu/about_indices_definition.php
     - UK DAQI: https://aqihub.info/indices/uk
     - Hong Kong AQHI: https://www.aqhi.gov.hk/en.html
+    - Ireland AQIH: https://aqihub.info/indices/ireland
     - Israel AQI: https://aqihub.info/indices/israel
     - Indonesia ISPU: https://aqihub.info/indices/indonesia
     - China AQI: https://aqihub.info/indices/china
@@ -161,8 +163,12 @@ NO2_AQI = [0, 50, 100, 150, 200, 300, 400, 500]
 
 # SO2 (Sulfur Dioxide, ppb) — EPA breakpoints
 # Breakpoints for 1-hour average SO2 concentrations
-SO2_BP = [0, 35, 75, 185, 304, 604, 804, 1004]
-SO2_AQI = [0, 50, 100, 150, 200, 300, 400, 500]
+# EPA SO2 Breakpoints
+SO2_BP = [0, 35, 75, 185, 304]
+SO2_AQI = [0, 50, 100, 150, 200]
+
+SO2_24H_BP = [305, 604, 804, 1004]
+SO2_24H_AQI = [201, 300, 400, 500]
 
 # CO (Carbon Monoxide, ppb) — EPA breakpoints
 # Breakpoints for 8-hour average CO concentrations
@@ -341,13 +347,14 @@ def compute_epa_aqi(
     o3_1h_ppb: float = float("nan"),
     no2_ppb: float = float("nan"),
     so2_ppb: float = float("nan"),
+    so2_24h_ppb: float = float("nan"),
     co_ppb: float = float("nan"),
 ) -> float:
     """Compute US EPA AQI as the maximum sub-index across available pollutants.
 
     Pollutant concentrations should be in model-native units:
       pm25_ug, pm10_ug → µg/m³
-      o3_8h_ppb, o3_1h_ppb, no2_ppb, so2_ppb, co_ppb → ppb
+      o3_8h_ppb, o3_1h_ppb, no2_ppb, so2_ppb, so2_24h_ppb, co_ppb → ppb
     """
     sub_indices = []
 
@@ -368,6 +375,16 @@ def compute_epa_aqi(
         if not math.isnan(o3_1h_sub):
             o3_sub = max(o3_sub, o3_1h_sub)
 
+    # SO2 logic: Try 1-hour breakpoint first; if > 200 (or > 304 ppb), fall back to 24-hour average
+    so2_sub = float("nan")
+    if not math.isnan(so2_ppb):
+        so2_sub = _epa_sub_index(so2_ppb, SO2_BP, SO2_AQI)
+
+    if (math.isnan(so2_sub) or so2_sub > 200) and not math.isnan(so2_24h_ppb):
+        so2_24h_sub = _epa_sub_index(so2_24h_ppb, SO2_24H_BP, SO2_24H_AQI)
+        if not math.isnan(so2_24h_sub):
+            so2_sub = so2_24h_sub
+
     if not math.isnan(pm25_ug):
         sub_indices.append(_epa_sub_index(pm25_ug, PM25_BP, PM25_AQI))
     if not math.isnan(pm10_ug):
@@ -376,8 +393,8 @@ def compute_epa_aqi(
         sub_indices.append(o3_sub)
     if not math.isnan(no2_ppb):
         sub_indices.append(_epa_sub_index(no2_ppb, NO2_BP, NO2_AQI))
-    if not math.isnan(so2_ppb):
-        sub_indices.append(_epa_sub_index(so2_ppb, SO2_BP, SO2_AQI))
+    if not math.isnan(so2_sub):
+        sub_indices.append(so2_sub)
     if not math.isnan(co_ppb):
         sub_indices.append(_epa_sub_index(co_ppb, CO_BP, CO_AQI))
 
@@ -465,7 +482,12 @@ def compute_hk_aqhi(
     pm25_ar = float("nan")
     pm10_ar = float("nan")
 
+    # Initialize all AR values to 0.0, so that if a pollutant is missing, it contributes 0 to the total AR
     pm_ar = 0.0
+    o3_ar = 0.0
+    no2_ar = 0.0
+    so2_ar = 0.0
+
     count = 0
     if not math.isnan(o3):
         o3_ar = (math.exp(HK_AQHI_BETA_O3 * o3) - 1) * 100
@@ -482,7 +504,7 @@ def compute_hk_aqhi(
         pm10_ar = (math.exp(HK_AQHI_BETA_PM10 * pm10) - 1) * 100
 
     if not math.isnan(pm25) or not math.isnan(pm10):
-        pm_ar += max(pm25_ar, pm10_ar)
+        pm_ar += np.nanmax([pm25_ar, pm10_ar])
         count += 1
     if count == 0:
         return float("nan")
@@ -661,7 +683,14 @@ def compute_iaqi(
         sub_indices.append(_aqi_from_breakpoints(co_mg, IAQI_CO_BP, IAQI_INDEX))
 
     valid = [v for v in sub_indices if not math.isnan(v)]
-    return 100 - float(max(valid)) if valid else float("nan")
+    # Israel AQI is defined as 100 to -400 (100 is best, 400 is worst), so we subtract the maximum sub-index from 100 to get the final AQI value.
+    worst_sub_index = float(max(valid)) if valid else float("nan")
+
+    return (
+        float(100 - worst_sub_index)
+        if not math.isnan(worst_sub_index)
+        else float("nan")
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -905,7 +934,10 @@ def compute_taiwan_aqi(
     """Compute Taiwan AQI as the maximum sub-index across available pollutants."""
     sub_indices = []
 
+    # Initialize all sub-index values to NaN
     o3_sub = float("nan")
+    sub_1h = float("nan")
+    sub_8h = float("nan")
 
     # 1. Calculate 8-hour sub-index (valid up to AQI 300)
     if not math.isnan(o3_8h_ppb):
@@ -970,7 +1002,10 @@ def compute_vn_aqi(
     so2_ug = so2_ppb * PPB_SO2_TO_UG_M3 if not math.isnan(so2_ppb) else float("nan")
     co_ug = co_ppb * PPB_CO_TO_UG_M3 if not math.isnan(co_ppb) else float("nan")
 
+    # Initialize all sub-indices to NaN
     o3_sub = float("nan")
+    sub_1h = float("nan")
+    sub_8h = float("nan")
 
     # 1. Calculate 8-hour sub-index (valid up to AQI 200)
     if not math.isnan(o3_8h_ug):
@@ -1043,7 +1078,7 @@ def compute_aqi_for_unit_system(
     """
     system = AQI_SYSTEM_MAP.get(unit_system, "EPA")
     if system == "EPA":
-        return compute_epa_aqi(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb, co_ppb)
+        return compute_epa_aqi(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb, so2_ppb, co_ppb)
     elif system == "AQHI":
         return compute_aqhi(pm25_ug, o3_ppb, no2_ppb)
     elif system == "DAQI":
@@ -1056,6 +1091,29 @@ def compute_aqi_for_unit_system(
         return compute_ispu(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb, co_ppb)
     elif system == "API":
         return compute_api(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb, co_ppb)
+    elif system == "IAQI":
+        return compute_iaqi(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb, co_ppb)
+    elif system == "CHINA_AQI":
+        return compute_china_aqi(
+            pm25_ug,
+            pm10_ug,
+            o3_ppb,
+            o3_ppb,
+            no2_ppb,
+            no2_ppb,
+            so2_ppb,
+            so2_ppb,
+            co_ppb,
+            co_ppb,
+        )
+    elif system == "TAQI":
+        return compute_taiwan_aqi(
+            pm25_ug, pm10_ug, o3_ppb, o3_ppb, no2_ppb, so2_ppb, co_ppb
+        )
+    elif system == "VN_AQI":
+        return compute_vn_aqi(
+            pm25_ug, pm10_ug, o3_ppb, o3_ppb, no2_ppb, so2_ppb, co_ppb
+        )
     else:  # EAQI
         return compute_caqi(pm25_ug, pm10_ug, o3_ppb, no2_ppb, so2_ppb)
 
@@ -1128,6 +1186,7 @@ def compute_aqi_array(
         pm10_calc = nowcast_pm(pm10_v)
         o3_calc = rolling_mean(o3_v, window=8)
         co_calc = rolling_mean(co_v, window=8)
+        so2_24h_calc = rolling_mean(so2_v, window=24)
         o3_1h_calc = o3_v
     elif system == "AQHI":
         # AQHI uses 3-hour rolling averages for PM2.5, O3, NO2
@@ -1154,12 +1213,12 @@ def compute_aqi_array(
     elif system == "ISPU":
         # Indonesia ISPU uses 24-hour rolling averages
         # PM2.5 is rounded to 1 decimal place, PM10, O3, NO2, SO2, CO are rounded to whole numbers
-        pm25_calc = round(rolling_mean(pm25_v, window=24), 1)
-        pm10_calc = round(rolling_mean(pm10_v, window=24), 0)
-        o3_calc = round(rolling_mean(o3_v, window=24), 0)
-        co_calc = round(rolling_mean(co_v, window=24), 0)
-        so2_calc = round(rolling_mean(so2_v, window=24), 0)
-        no2_calc = round(rolling_mean(no2_v, window=24), 0)
+        pm25_calc = np.round(rolling_mean(pm25_v, window=24), 1)
+        pm10_calc = np.round(rolling_mean(pm10_v, window=24), 0)
+        o3_calc = np.round(rolling_mean(o3_v, window=24), 0)
+        co_calc = np.round(rolling_mean(co_v, window=24), 0)
+        so2_calc = np.round(rolling_mean(so2_v, window=24), 0)
+        no2_calc = np.round(rolling_mean(no2_v, window=24), 0)
     elif system == "CHINA_AQI":
         # China AQI uses 24-hour rolling averages for PM2.5, PM10, NO2, SO2, CO and 8-hour rolling average for O3
         pm25_calc = rolling_mean(pm25_v, window=24)
@@ -1170,32 +1229,32 @@ def compute_aqi_array(
         co_24_calc = rolling_mean(co_v, window=24)
     elif system == "API":
         # Malayia rounds everything to nearest whole number
-        pm25_calc = round(pm25_v, 0)
-        pm10_calc = round(pm10_v, 0)
-        o3_calc = round(o3_v, 0)
-        no2_calc = round(no2_v, 0)
-        so2_calc = round(so2_v, 0)
-        co_calc = round(co_v, 0)
+        pm25_calc = np.round(pm25_v, 0)
+        pm10_calc = np.round(pm10_v, 0)
+        o3_calc = np.round(o3_v, 0)
+        no2_calc = np.round(no2_v, 0)
+        so2_calc = np.round(so2_v, 0)
+        co_calc = np.round(co_v, 0)
     elif system == "TAQI":
         # Taiwan AQI uses 24-hour rolling averages for PM2.5, PM10, 8-hour for O3, and 1-hour for NO2, SO2, CO
         # For PM2.5, round to 1 decimal place; for PM10, O3, NO2, SO2, CO round to whole numbers
-        pm25_calc = round(rolling_mean(pm25_v, window=24), 1)
-        pm10_calc = round(rolling_mean(pm10_v, window=24), 0)
-        o3_8h_calc = round(rolling_mean(o3_v, window=8), 0)
-        o3_1h_calc = round(rolling_mean(o3_v, window=1), 0)
-        no2_calc = round(rolling_mean(no2_v, window=24), 0)
-        so2_calc = round(rolling_mean(so2_v, window=24), 0)
-        co_calc = round(rolling_mean(co_v, window=24), 0)
+        pm25_calc = np.round(rolling_mean(pm25_v, window=24), 1)
+        pm10_calc = np.round(rolling_mean(pm10_v, window=24), 0)
+        o3_8h_calc = np.round(rolling_mean(o3_v, window=8), 0)
+        o3_calc = np.round(rolling_mean(o3_v, window=1), 0)
+        no2_calc = np.round(rolling_mean(no2_v, window=24), 0)
+        so2_calc = np.round(rolling_mean(so2_v, window=24), 0)
+        co_calc = np.round(rolling_mean(co_v, window=24), 0)
     elif system == "VN_AQI":
         # Vietnam AQI uses nowcast for PM2.5, PM10, 8-hour for O3, and 1-hour for NO2, SO2, CO
         # For all pollutants, round to whole numbers
-        pm25_calc = round(nowcast_pm(pm25_v), 0)
-        pm10_calc = round(nowcast_pm(pm10_v), 0)
-        o3_8h_calc = round(rolling_mean(o3_v, window=8), 0)
-        o3_calc = round(o3_v, 0)
-        no2_calc = round(no2_v, 0)
-        so2_calc = round(so2_v, 0)
-        co_calc = round(co_v, 0)
+        pm25_calc = np.round(nowcast_pm(pm25_v), 0)
+        pm10_calc = np.round(nowcast_pm(pm10_v), 0)
+        o3_8h_calc = np.round(rolling_mean(o3_v, window=8), 0)
+        o3_calc = np.round(o3_v, 0)
+        no2_calc = np.round(no2_v, 0)
+        so2_calc = np.round(so2_v, 0)
+        co_calc = np.round(co_v, 0)
 
     result = np.full(n, np.nan, dtype=np.float32)
     for i in range(n):
@@ -1207,6 +1266,7 @@ def compute_aqi_array(
                 o3_1h_ppb=float(o3_1h_calc[i]),
                 no2_ppb=float(no2_calc[i]),
                 so2_ppb=float(so2_calc[i]),
+                so2_24h_ppb=float(so2_24h_calc[i]),
                 co_ppb=float(co_calc[i]),
             )
         elif system == "CHINA_AQI":
@@ -1214,7 +1274,7 @@ def compute_aqi_array(
                 pm25_ug=float(pm25_calc[i]),
                 pm10_ug=float(pm10_calc[i]),
                 o3_8h_ppb=float(o3_8h_calc[i]),
-                o3_1h_ppb=float(o3_1h_calc[i]),
+                o3_1h_ppb=float(o3_calc[i]),
                 no2_24h_ppb=float(no2_24_calc[i]),
                 so2_24h_ppb=float(so2_24_calc[i]),
                 co_24h_ppb=float(co_24_calc[i]),

--- a/API/request/preprocess.py
+++ b/API/request/preprocess.py
@@ -700,10 +700,36 @@ async def prepare_initial_request(
 
     unit_system, unit_config = _setup_units(units, loc_name)
 
-    # Parse aqiunits override: ca → AQHI, us → EPA, eu → CAQI.
+    # Parse aqiunits override: ca → AQHI, us → EPA, eu → CAQI, uk → DAQI, hk → HK_AQHI, ie → AQIH, il → Israel AQI, id → ISPU, cn → China AQI, my → API, tw → Taiwan AQI, vn → VN_AQI.
     # Falls back to the unit-based AQI system when the value is absent or invalid.
-    _VALID_AQI_UNITS = {"ca", "us", "eu", "uk", "hk"}
-    _AQI_UNITS_MAP = {"ca": "ca", "us": "us", "eu": "si", "uk": "uk", "hk": "hk"}
+    _VALID_AQI_UNITS = {
+        "ca",
+        "us",
+        "eu",
+        "uk",
+        "hk",
+        "ie",
+        "il",
+        "id",
+        "cn",
+        "my",
+        "tw",
+        "vn",
+    }
+    _AQI_UNITS_MAP = {
+        "ca": "ca",
+        "us": "us",
+        "eu": "si",
+        "uk": "uk",
+        "hk": "hk",
+        "ie": "ie",
+        "il": "il",
+        "id": "id",
+        "cn": "cn",
+        "my": "my",
+        "tw": "tw",
+        "vn": "vn",
+    }
     raw_aqiunits = request.query_params.get("aqiunits")
     if raw_aqiunits and raw_aqiunits.lower() in _VALID_AQI_UNITS:
         aqi_system = _AQI_UNITS_MAP[raw_aqiunits.lower()]

--- a/API/request/preprocess.py
+++ b/API/request/preprocess.py
@@ -702,8 +702,8 @@ async def prepare_initial_request(
 
     # Parse aqiunits override: ca → AQHI, us → EPA, eu → CAQI.
     # Falls back to the unit-based AQI system when the value is absent or invalid.
-    _VALID_AQI_UNITS = {"ca", "us", "eu", "uk"}
-    _AQI_UNITS_MAP = {"ca": "ca", "us": "us", "eu": "si", "uk": "uk"}
+    _VALID_AQI_UNITS = {"ca", "us", "eu", "uk", "hk"}
+    _AQI_UNITS_MAP = {"ca": "ca", "us": "us", "eu": "si", "uk": "uk", "hk": "hk"}
     raw_aqiunits = request.query_params.get("aqiunits")
     if raw_aqiunits and raw_aqiunits.lower() in _VALID_AQI_UNITS:
         aqi_system = _AQI_UNITS_MAP[raw_aqiunits.lower()]

--- a/API/request/preprocess.py
+++ b/API/request/preprocess.py
@@ -713,7 +713,6 @@ async def prepare_initial_request(
         "id",
         "cn",
         "my",
-        "tw",
         "vn",
     }
     _AQI_UNITS_MAP = {
@@ -727,7 +726,6 @@ async def prepare_initial_request(
         "id": "id",
         "cn": "cn",
         "my": "my",
-        "tw": "tw",
         "vn": "vn",
     }
     raw_aqiunits = request.query_params.get("aqiunits")

--- a/tests/test_aqi_calculations.py
+++ b/tests/test_aqi_calculations.py
@@ -7,13 +7,20 @@ import pytest
 
 from API.constants.aqi_const import (
     AQI_SYSTEM_MAP,
+    compute_api,
     compute_aqhi,
     compute_aqi_array,
     compute_aqi_for_unit_system,
+    compute_aqih,
     compute_caqi,
+    compute_china_aqi,
     compute_daqi,
     compute_epa_aqi,
     compute_hk_aqhi,
+    compute_iaqi,
+    compute_ispu,
+    compute_taiwan_aqi,
+    compute_vn_aqi,
     nowcast_pm,
     rolling_mean,
 )
@@ -172,6 +179,245 @@ class TestDAQI:
 
 
 # ---------------------------------------------------------------------------
+# Ireland AQIH tests
+# ---------------------------------------------------------------------------
+
+
+class TestAQIH:
+    def test_clean_air_returns_low_aqih(self):
+        """Low pollutant concentrations should yield an index in the 'Low' band (1–3)."""
+        aqih = compute_aqih(
+            pm25_ug=5.0, pm10_ug=10.0, o3_ppb=20.0, no2_ppb=5.0, so2_ppb=7.0
+        )
+        assert 1 <= aqih <= 3
+
+    def test_high_pollutants_return_high_aqih(self):
+        """Elevated concentrations should push AQIH into upper bands."""
+        aqih = compute_aqih(
+            pm25_ug=80.0, pm10_ug=100.0, o3_ppb=300.0, no2_ppb=200.0, so2_ppb=90.0
+        )
+        assert aqih >= 8
+
+    def test_so2_breakpoints_differ_from_daqi(self):
+        """AQIH uses distinct SO2 breakpoints compared to UK DAQI."""
+        aqih = compute_aqih(so2_ppb=30.0)
+        daqi = compute_daqi(so2_ppb=30.0)
+        assert aqih != daqi
+
+    def test_nan_inputs_return_nan(self):
+        """All-NaN inputs should return NaN."""
+        aqih = compute_aqih()
+        assert math.isnan(aqih)
+
+
+# ---------------------------------------------------------------------------
+# Israel IAQI tests
+# ---------------------------------------------------------------------------
+
+
+class TestIAQI:
+    def test_clean_air_returns_high_best_side_value(self):
+        """IAQI returns 100 for best air and decreases as pollution increases."""
+        iaqi = compute_iaqi(
+            pm25_ug=2.0,
+            pm10_ug=5.0,
+            o3_ppb=5.0,
+            no2_ppb=5.0,
+            so2_ppb=5.0,
+            co_ppb=100.0,
+        )
+        assert iaqi >= 75
+
+    def test_high_pollutants_return_negative_value(self):
+        """Severe pollution should push IAQI below zero on its inverted scale."""
+        iaqi = compute_iaqi(
+            pm25_ug=500.0,
+            pm10_ug=500.0,
+            o3_ppb=1000.0,
+            no2_ppb=2000.0,
+            so2_ppb=2000.0,
+            co_ppb=200000.0,
+        )
+        assert iaqi < 0
+
+    def test_nan_inputs_return_nan(self):
+        iaqi = compute_iaqi()
+        assert math.isnan(iaqi)
+
+
+# ---------------------------------------------------------------------------
+# Indonesia ISPU tests
+# ---------------------------------------------------------------------------
+
+
+class TestISPU:
+    def test_low_pollutants_return_low_ispu(self):
+        ispu = compute_ispu(
+            pm25_ug=5.0, pm10_ug=10.0, o3_ppb=5.0, no2_ppb=5.0, so2_ppb=5.0, co_ppb=10.0
+        )
+        assert 0 <= ispu <= 50
+
+    def test_high_pollutants_return_high_ispu(self):
+        ispu = compute_ispu(
+            pm25_ug=250.0,
+            pm10_ug=420.0,
+            o3_ppb=500.0,
+            no2_ppb=1000.0,
+            so2_ppb=500.0,
+            co_ppb=50000.0,
+        )
+        assert ispu >= 200
+
+    def test_nan_inputs_return_nan(self):
+        ispu = compute_ispu()
+        assert math.isnan(ispu)
+
+
+# ---------------------------------------------------------------------------
+# China AQI tests
+# ---------------------------------------------------------------------------
+
+
+class TestChinaAQI:
+    def test_low_pollutants_return_low_aqi(self):
+        china = compute_china_aqi(
+            pm25_ug=10.0,
+            pm10_ug=20.0,
+            o3_8h_ppb=20.0,
+            o3_1h_ppb=20.0,
+            no2_1h_ppb=10.0,
+            no2_24h_ppb=10.0,
+            so2_1h_ppb=5.0,
+            so2_24h_ppb=5.0,
+            co_1h_ppb=500.0,
+            co_24h_ppb=500.0,
+        )
+        assert 0 <= china <= 100
+
+    def test_high_pollutants_return_high_aqi(self):
+        china = compute_china_aqi(
+            pm25_ug=250.0,
+            pm10_ug=420.0,
+            o3_8h_ppb=300.0,
+            o3_1h_ppb=500.0,
+            no2_1h_ppb=1200.0,
+            no2_24h_ppb=1000.0,
+            so2_1h_ppb=800.0,
+            so2_24h_ppb=800.0,
+            co_1h_ppb=90000.0,
+            co_24h_ppb=60000.0,
+        )
+        assert china >= 200
+
+    def test_nan_inputs_return_nan(self):
+        china = compute_china_aqi()
+        assert math.isnan(china)
+
+
+# ---------------------------------------------------------------------------
+# Malaysia API tests
+# ---------------------------------------------------------------------------
+
+
+class TestMalaysiaAPI:
+    def test_low_pollutants_return_low_api(self):
+        api = compute_api(
+            pm25_ug=20.0,
+            pm10_ug=30.0,
+            o3_ppb=20.0,
+            no2_ppb=20.0,
+            so2_ppb=20.0,
+            co_ppb=1000.0,
+        )
+        assert 0 <= api <= 50
+
+    def test_high_pollutants_return_high_api(self):
+        api = compute_api(
+            pm25_ug=300.0,
+            pm10_ug=400.0,
+            o3_ppb=300.0,
+            no2_ppb=400.0,
+            so2_ppb=300.0,
+            co_ppb=9000.0,
+        )
+        assert api >= 200
+
+    def test_nan_inputs_return_nan(self):
+        api = compute_api()
+        assert math.isnan(api)
+
+
+# ---------------------------------------------------------------------------
+# Taiwan AQI tests
+# ---------------------------------------------------------------------------
+
+
+class TestTaiwanAQI:
+    def test_low_pollutants_return_low_aqi(self):
+        taqi = compute_taiwan_aqi(
+            pm25_ug=10.0,
+            pm10_ug=20.0,
+            o3_8h_ppb=30.0,
+            o3_1h_ppb=30.0,
+            no2_ppb=10.0,
+            so2_ppb=10.0,
+            co_ppb=1000.0,
+        )
+        assert 0 <= taqi <= 100
+
+    def test_high_pollutants_return_high_aqi(self):
+        taqi = compute_taiwan_aqi(
+            pm25_ug=200.0,
+            pm10_ug=400.0,
+            o3_8h_ppb=150.0,
+            o3_1h_ppb=300.0,
+            no2_ppb=1000.0,
+            so2_ppb=500.0,
+            co_ppb=40000.0,
+        )
+        assert taqi >= 200
+
+    def test_nan_inputs_return_nan(self):
+        taqi = compute_taiwan_aqi()
+        assert math.isnan(taqi)
+
+
+# ---------------------------------------------------------------------------
+# Vietnam VN_AQI tests
+# ---------------------------------------------------------------------------
+
+
+class TestVNAQI:
+    def test_low_pollutants_return_low_aqi(self):
+        vn = compute_vn_aqi(
+            pm25_ug=10.0,
+            pm10_ug=20.0,
+            o3_8h_ppb=20.0,
+            o3_1h_ppb=20.0,
+            no2_ppb=5.0,
+            so2_ppb=5.0,
+            co_ppb=1000.0,
+        )
+        assert 0 <= vn <= 100
+
+    def test_high_pollutants_return_high_aqi(self):
+        vn = compute_vn_aqi(
+            pm25_ug=250.0,
+            pm10_ug=450.0,
+            o3_8h_ppb=300.0,
+            o3_1h_ppb=500.0,
+            no2_ppb=2000.0,
+            so2_ppb=1000.0,
+            co_ppb=80000.0,
+        )
+        assert vn >= 200
+
+    def test_nan_inputs_return_nan(self):
+        vn = compute_vn_aqi()
+        assert math.isnan(vn)
+
+
+# ---------------------------------------------------------------------------
 # Unit-system dispatch tests
 # ---------------------------------------------------------------------------
 
@@ -185,6 +431,13 @@ class TestAQISystemDispatch:
             ("uk", "DAQI"),
             ("si", "CAQI"),
             ("hk", "HK_AQHI"),
+            ("ie", "AQIH"),
+            ("il", "IAQI"),
+            ("id", "ISPU"),
+            ("cn", "CHINA_AQI"),
+            ("my", "API"),
+            ("tw", "TAQI"),
+            ("vn", "VN_AQI"),
             ("unknown", "EPA"),  # default
         ],
     )
@@ -225,6 +478,53 @@ class TestAQISystemDispatch:
             "hk", pm25_ug=20.0, pm10_ug=40.0, o3_ppb=60.0, no2_ppb=30.0, so2_ppb=10.0
         )
         assert abs(dispatched - hk_aqhi) < 1e-6
+
+    def test_ie_returns_aqih_value(self):
+        aqih = compute_aqih(pm25_ug=20.0, pm10_ug=40.0, o3_ppb=60.0, no2_ppb=30.0)
+        dispatched = compute_aqi_for_unit_system(
+            "ie", pm25_ug=20.0, pm10_ug=40.0, o3_ppb=60.0, no2_ppb=30.0
+        )
+        assert abs(dispatched - aqih) < 1e-6
+
+    def test_id_returns_ispu_value(self):
+        ispu = compute_ispu(
+            pm25_ug=20.0,
+            pm10_ug=40.0,
+            o3_ppb=60.0,
+            no2_ppb=30.0,
+            so2_ppb=10.0,
+            co_ppb=500.0,
+        )
+        dispatched = compute_aqi_for_unit_system(
+            "id",
+            pm25_ug=20.0,
+            pm10_ug=40.0,
+            o3_ppb=60.0,
+            no2_ppb=30.0,
+            so2_ppb=10.0,
+            co_ppb=500.0,
+        )
+        assert abs(dispatched - ispu) < 1e-6
+
+    def test_my_returns_api_value(self):
+        api = compute_api(
+            pm25_ug=20.0,
+            pm10_ug=40.0,
+            o3_ppb=60.0,
+            no2_ppb=30.0,
+            so2_ppb=10.0,
+            co_ppb=500.0,
+        )
+        dispatched = compute_aqi_for_unit_system(
+            "my",
+            pm25_ug=20.0,
+            pm10_ug=40.0,
+            o3_ppb=60.0,
+            no2_ppb=30.0,
+            so2_ppb=10.0,
+            co_ppb=500.0,
+        )
+        assert abs(dispatched - api) < 1e-6
 
 
 # ---------------------------------------------------------------------------
@@ -665,6 +965,79 @@ class TestDAQIAveragingInArray:
         assert result[-1] == 2
 
 
+class TestAQIHAveragingInArray:
+    """Tests confirming AQIH uses DAQI-like averaging windows."""
+
+    def test_aqih_pm25_uses_24h_rolling_mean(self):
+        conc = np.concatenate([np.full(23, 5.0), [80.0]])
+        result = compute_aqi_array(
+            "ie", pm25=conc, pm10=None, o3=None, no2=None, so2=None, co=None
+        )
+        assert result[-1] == 1
+
+
+class TestIAQIAveragingInArray:
+    """Tests confirming IAQI mixed averaging behavior is applied."""
+
+    def test_iaqi_pm25_uses_24h_rolling_mean(self):
+        conc = np.concatenate([np.full(23, 5.0), [200.0]])
+        result = compute_aqi_array(
+            "il", pm25=conc, pm10=None, o3=None, no2=None, so2=None, co=None
+        )
+        raw_iaqi = compute_iaqi(pm25_ug=200.0)
+        # Because IAQI is inverted (higher is better), averaging should keep result above
+        # the raw single-hour spike value.
+        assert result[-1] > raw_iaqi
+
+
+class TestISPUAveragingInArray:
+    """Tests confirming ISPU applies 24h rolling means and rounding."""
+
+    def test_ispu_pm25_uses_24h_rolling_mean(self):
+        conc = np.concatenate([np.full(23, 5.0), [250.0]])
+        result = compute_aqi_array(
+            "id", pm25=conc, pm10=None, o3=None, no2=None, so2=None, co=None
+        )
+        raw_ispu = compute_ispu(pm25_ug=250.0)
+        assert result[-1] < raw_ispu
+
+
+class TestChinaAveragingInArray:
+    """Tests confirming China AQI rolling windows are applied."""
+
+    def test_china_pm25_uses_24h_rolling_mean(self):
+        conc = np.concatenate([np.full(23, 5.0), [250.0]])
+        result = compute_aqi_array(
+            "cn", pm25=conc, pm10=None, o3=None, no2=None, so2=None, co=None
+        )
+        raw_china = compute_china_aqi(pm25_ug=250.0)
+        assert result[-1] < raw_china
+
+
+class TestTaiwanAveragingInArray:
+    """Tests confirming Taiwan AQI mixed averaging behavior is applied."""
+
+    def test_taiwan_pm25_uses_24h_rolling_mean(self):
+        conc = np.concatenate([np.full(23, 5.0), [200.0]])
+        result = compute_aqi_array(
+            "tw", pm25=conc, pm10=None, o3=None, no2=None, so2=None, co=None
+        )
+        raw_taqi = compute_taiwan_aqi(pm25_ug=200.0)
+        assert result[-1] < raw_taqi
+
+
+class TestVNAQIAveragingInArray:
+    """Tests confirming Vietnam VN_AQI mixed averaging behavior is applied."""
+
+    def test_vn_aqi_pm25_uses_nowcast(self):
+        conc = np.concatenate([np.full(12, 5.0), [250.0]])
+        result = compute_aqi_array(
+            "vn", pm25=conc, pm10=None, o3=None, no2=None, so2=None, co=None
+        )
+        raw_vn = compute_vn_aqi(pm25_ug=250.0)
+        assert result[-1] < raw_vn
+
+
 class TestAQIUnitsQueryParam:
     """Tests for the aqiunits query-parameter override logic."""
 
@@ -702,7 +1075,7 @@ class TestAQIUnitsQueryParam:
         # EPA AQI for 50 µg/m³ PM2.5 (NowCast-averaged) should be > 100
         assert float(result_us[-1]) > 100
 
-    def test_uk_aqiunits_uses_who(self):
+    def test_uk_aqiunits_uses_daqi(self):
         """aqiunits=uk should produce DAQI (same as uk unit system)."""
         pm25 = np.full(3, 50.0)
         result_uk = compute_aqi_array(

--- a/tests/test_aqi_calculations.py
+++ b/tests/test_aqi_calculations.py
@@ -19,7 +19,6 @@ from API.constants.aqi_const import (
     compute_hk_aqhi,
     compute_iaqi,
     compute_ispu,
-    compute_taiwan_aqi,
     compute_vn_aqi,
     nowcast_pm,
     rolling_mean,
@@ -345,41 +344,6 @@ class TestMalaysiaAPI:
     def test_nan_inputs_return_nan(self):
         api = compute_api()
         assert math.isnan(api)
-
-
-# ---------------------------------------------------------------------------
-# Taiwan AQI tests
-# ---------------------------------------------------------------------------
-
-
-class TestTaiwanAQI:
-    def test_low_pollutants_return_low_aqi(self):
-        taqi = compute_taiwan_aqi(
-            pm25_ug=10.0,
-            pm10_ug=20.0,
-            o3_8h_ppb=30.0,
-            o3_1h_ppb=30.0,
-            no2_ppb=10.0,
-            so2_ppb=10.0,
-            co_ppb=1000.0,
-        )
-        assert 0 <= taqi <= 100
-
-    def test_high_pollutants_return_high_aqi(self):
-        taqi = compute_taiwan_aqi(
-            pm25_ug=200.0,
-            pm10_ug=400.0,
-            o3_8h_ppb=150.0,
-            o3_1h_ppb=300.0,
-            no2_ppb=1000.0,
-            so2_ppb=500.0,
-            co_ppb=40000.0,
-        )
-        assert taqi >= 200
-
-    def test_nan_inputs_return_nan(self):
-        taqi = compute_taiwan_aqi()
-        assert math.isnan(taqi)
 
 
 # ---------------------------------------------------------------------------
@@ -1012,18 +976,6 @@ class TestChinaAveragingInArray:
         )
         raw_china = compute_china_aqi(pm25_ug=250.0)
         assert result[-1] < raw_china
-
-
-class TestTaiwanAveragingInArray:
-    """Tests confirming Taiwan AQI mixed averaging behavior is applied."""
-
-    def test_taiwan_pm25_uses_24h_rolling_mean(self):
-        conc = np.concatenate([np.full(23, 5.0), [200.0]])
-        result = compute_aqi_array(
-            "tw", pm25=conc, pm10=None, o3=None, no2=None, so2=None, co=None
-        )
-        raw_taqi = compute_taiwan_aqi(pm25_ug=200.0)
-        assert result[-1] < raw_taqi
 
 
 class TestVNAQIAveragingInArray:

--- a/tests/test_aqi_calculations.py
+++ b/tests/test_aqi_calculations.py
@@ -13,6 +13,7 @@ from API.constants.aqi_const import (
     compute_caqi,
     compute_daqi,
     compute_epa_aqi,
+    compute_hk_aqhi,
     nowcast_pm,
     rolling_mean,
 )
@@ -58,7 +59,7 @@ class TestEPAAQI:
 
 
 # ---------------------------------------------------------------------------
-# AQHI tests
+# Canadian AQHI tests
 # ---------------------------------------------------------------------------
 
 
@@ -81,6 +82,32 @@ class TestAQHI:
     def test_nan_inputs_return_nan(self):
         """All NaN → NaN."""
         aqhi = compute_aqhi()
+        assert math.isnan(aqhi)
+
+# ---------------------------------------------------------------------------
+# Hong Kong AQHI tests
+# ---------------------------------------------------------------------------
+
+
+class TestHK_AQHI:
+    def test_clean_air_returns_low_hk_aqhi(self):
+        """Very low concentrations → AQHI close to 1."""
+        aqhi = compute_hk_aqhi(pm25_ug=2.0, pm10_ug=5.0, o3_ppb=10.0, no2_ppb=5.0, so2_ppb=1.0)
+        assert aqhi == 1
+
+    def test_high_concentrations_return_high_hk_aqhi(self):
+        """Elevated O3/NO2 should push AQHI above 7."""
+        aqhi = compute_hk_aqhi(pm25_ug=35.0, pm10_ug=65.0, o3_ppb=40.0, no2_ppb=5.0, so2_ppb=150.0)
+        assert aqhi == 7
+
+    def test_extreme_concentrations_cap_aqhi_at_11(self):
+        """Extreme concentrations should not report AQHI above 11."""
+        aqhi = compute_hk_aqhi(pm25_ug=5000.0, pm10_ug=5000.0, o3_ppb=5000.0, no2_ppb=5000.0, so2_ppb=5000.0)
+        assert aqhi == 11.0
+
+    def test_nan_inputs_return_nan(self):
+        """All NaN → NaN."""
+        aqhi = compute_hk_aqhi()
         assert math.isnan(aqhi)
 
 
@@ -146,6 +173,7 @@ class TestAQISystemDispatch:
             ("ca", "AQHI"),
             ("uk", "DAQI"),
             ("si", "CAQI"),
+            ("hk", "HK_AQHI"),
             ("unknown", "EPA"),  # default
         ],
     )
@@ -177,6 +205,14 @@ class TestAQISystemDispatch:
             "uk", pm25_ug=20.0, pm10_ug=40.0, o3_ppb=60.0, no2_ppb=30.0
         )
         assert abs(dispatched - daqi) < 1e-6
+
+    def test_hk_returns_hk_aqhi_value(self):
+        hk_aqhi = compute_hk_aqhi(pm25_ug=20.0, pm10_ug=40.0, o3_ppb=60.0, no2_ppb=30.0, so2_ppb=10.0)
+        dispatched = compute_aqi_for_unit_system(
+            "hk", pm25_ug=20.0, pm10_ug=40.0, o3_ppb=60.0, no2_ppb=30.0, so2_ppb=10.0
+        )
+        assert abs(dispatched - hk_aqhi) < 1e-6
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_aqi_calculations.py
+++ b/tests/test_aqi_calculations.py
@@ -84,6 +84,7 @@ class TestAQHI:
         aqhi = compute_aqhi()
         assert math.isnan(aqhi)
 
+
 # ---------------------------------------------------------------------------
 # Hong Kong AQHI tests
 # ---------------------------------------------------------------------------
@@ -92,17 +93,27 @@ class TestAQHI:
 class TestHK_AQHI:
     def test_clean_air_returns_low_hk_aqhi(self):
         """Very low concentrations → AQHI close to 1."""
-        aqhi = compute_hk_aqhi(pm25_ug=2.0, pm10_ug=5.0, o3_ppb=10.0, no2_ppb=5.0, so2_ppb=1.0)
+        aqhi = compute_hk_aqhi(
+            pm25_ug=2.0, pm10_ug=5.0, o3_ppb=10.0, no2_ppb=5.0, so2_ppb=1.0
+        )
         assert aqhi == 1
 
     def test_high_concentrations_return_high_hk_aqhi(self):
         """Elevated O3/NO2 should push AQHI above 7."""
-        aqhi = compute_hk_aqhi(pm25_ug=35.0, pm10_ug=65.0, o3_ppb=40.0, no2_ppb=5.0, so2_ppb=150.0)
+        aqhi = compute_hk_aqhi(
+            pm25_ug=35.0, pm10_ug=65.0, o3_ppb=40.0, no2_ppb=5.0, so2_ppb=150.0
+        )
         assert aqhi == 7
 
     def test_extreme_concentrations_cap_aqhi_at_11(self):
         """Extreme concentrations should not report AQHI above 11."""
-        aqhi = compute_hk_aqhi(pm25_ug=5000.0, pm10_ug=5000.0, o3_ppb=5000.0, no2_ppb=5000.0, so2_ppb=5000.0)
+        aqhi = compute_hk_aqhi(
+            pm25_ug=5000.0,
+            pm10_ug=5000.0,
+            o3_ppb=5000.0,
+            no2_ppb=5000.0,
+            so2_ppb=5000.0,
+        )
         assert aqhi == 11.0
 
     def test_nan_inputs_return_nan(self):
@@ -207,12 +218,13 @@ class TestAQISystemDispatch:
         assert abs(dispatched - daqi) < 1e-6
 
     def test_hk_returns_hk_aqhi_value(self):
-        hk_aqhi = compute_hk_aqhi(pm25_ug=20.0, pm10_ug=40.0, o3_ppb=60.0, no2_ppb=30.0, so2_ppb=10.0)
+        hk_aqhi = compute_hk_aqhi(
+            pm25_ug=20.0, pm10_ug=40.0, o3_ppb=60.0, no2_ppb=30.0, so2_ppb=10.0
+        )
         dispatched = compute_aqi_for_unit_system(
             "hk", pm25_ug=20.0, pm10_ug=40.0, o3_ppb=60.0, no2_ppb=30.0, so2_ppb=10.0
         )
         assert abs(dispatched - hk_aqhi) < 1e-6
-
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Describe the change
Adds support for some more regional air quality indexes. Not all the ones found on the site just the ones that I think make the most sense to add and aren't overly complex.

When the next version goes out I'll create a template where people can request more local air quality indexes and we can go from there.

From the list I'm looking to add:

- [x] China
- [x] Hong Kong
- [x] Indonesia
- [x] Ireland
- [x] Israel
- [x] Malaysia
- [x] Taiwan
- [x] Vietnam

## Type of change

- [ ] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [x] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [ ] Code has been formatted using ruff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added air-quality index support for Hong Kong, Ireland, Israel, Indonesia, China, Malaysia, Taiwan, and Vietnam.
  - Added region-specific pollutant conversions, averaging periods, and calculation rules.
  - Added support for separate averaging-period inputs where required by China and Taiwan.
  - Improved EPA sulfur dioxide calculations across applicable 1-hour and 24-hour measurements.

- **Bug Fixes**
  - AQI unit selections now correctly recognize and route all newly supported regional systems.

- **Tests**
  - Expanded coverage for low and high pollution levels, missing values, rolling averages, and NowCast behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->