### PR TITLE
Add new ingest testing and fix zip file syncing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@
 PW_WEATHER_ROOT=/mnt/pirate-weather/Weather
 PW_WORK_ROOT=/mnt/pirate-weather/Work
 
+# Optional: enables live ingest comparisons against GribStream.
+GRIBSTREAM_API_KEY=

--- a/.github/workflows/rtma-ingest-test.yml
+++ b/.github/workflows/rtma-ingest-test.yml
@@ -10,6 +10,8 @@ jobs:
   ingest-test:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
+    env:
+      GRIBSTREAM_API_KEY: ${{ secrets.GRIBSTREAM_API_KEY }}
     permissions:
       contents: read
     steps:

--- a/API/utils/geo.py
+++ b/API/utils/geo.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import datetime
 import math
-
-from pytz import timezone, utc
-from timezonefinder import TimezoneFinder
+from typing import TYPE_CHECKING
 
 from API.constants.api_const import (
     DEFAULT_ROUNDING_INTERVAL,
@@ -16,6 +14,9 @@ from API.constants.api_const import (
     UNIT_CONVERSION_CONST,
 )
 from API.constants.grid_const import US_BOUNDING_BOX
+
+if TYPE_CHECKING:
+    from timezonefinder import TimezoneFinder
 
 
 def haversine_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
@@ -71,6 +72,8 @@ def get_offset(*, lat, lng, utc_time, tf: TimezoneFinder):
             offset_minutes: The time zone offset from UTC in minutes.
             tz_target: The pytz timezone object for the location.
     """
+
+    from pytz import timezone, utc
 
     today = utc_time
     tz_target = timezone(tf.timezone_at(lng=lng, lat=lat))

--- a/API/zip_sync.sh
+++ b/API/zip_sync.sh
@@ -32,14 +32,18 @@ MODELS="
   ECMWF
   ECMWF_AIFS
   ETOPO_DA_C
+  GDPS
   GEFS
+  GEPS
   GFS
+  HRDPS
   HRRR
   HRRR_6H
   NBM
   NBM_Fire
   NWS_Alerts
   RAQDPS
+  REPS
   RTMA_RU
   SILAM
   SubH

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,7 +7,9 @@ import os as _os
 import warnings as _warnings
 from pathlib import Path as _Path
 
-_ENV_DEFAULT_KEYS = frozenset({"PW_API", "AWS_KEY", "AWS_SECRET", "s3_bucket"})
+_ENV_DEFAULT_KEYS = frozenset(
+    {"PW_API", "AWS_KEY", "AWS_SECRET", "GRIBSTREAM_API_KEY", "s3_bucket"}
+)
 
 
 class DiffWarning(UserWarning):

--- a/tests/test_compare_production.py
+++ b/tests/test_compare_production.py
@@ -12,7 +12,7 @@ from tests.test_s3_live import _get_client
 
 PW_API = os.environ.get("PW_API")
 PROD_BASE = "https://api.pirateweather.net/forecast"
-PROD_TIMEMACHINE_BASE = "https://api.pirateweather.net/timemachine"
+PROD_TIMEMACHINE_BASE = "https://timemachine.pirateweather.net/forecast"
 
 TIMEMACHINE_TEST_LOCATION = (45.4215, -75.6972)  # Ottawa, Canada
 TIMEMACHINE_TEST_DATE = datetime.datetime(2020, 6, 15, tzinfo=datetime.UTC)

--- a/tests/test_hrrr_6h_ingest.py
+++ b/tests/test_hrrr_6h_ingest.py
@@ -1,20 +1,58 @@
 """Live ingest test for the HRRR_6H ingest script."""
 
+import datetime
+import json
+import math
 import os
+import pickle
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 import pytest
 import zarr
 
+from API.constants.model_const import HRRR
 from API.constants.shared_const import INGEST_VERSION_STR
+from API.utils.geo import lambertGridMatch
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "API" / "HRRR_6H_Local_Ingest.py"
 REPO_ROOT = Path(__file__).resolve().parents[1]
 EXPECTED_VAR_COUNT = 20
 LOCAL_TEST_ENV_VAR = "PW_RUN_LOCAL_INGEST_TESTS"
+GRIBSTREAM_API_KEY_ENV_VAR = "GRIBSTREAM_API_KEY"
+GRIBSTREAM_HRRR_RUNS_URL = "https://gribstream.com/api/v2/hrrr/runs"
+GRIBSTREAM_COMPARISON_LEAD_HOURS = 18
+GRIBSTREAM_COMPARISON_LOCATION = (40.0, -105.0)
+GRIBSTREAM_VARIABLES = (
+    {
+        "alias": "temperature",
+        "zarr_index": HRRR["temp"],
+        "absolute_tolerance": 0.1,
+        "selector": {"name": "TMP", "level": "2 m above ground", "info": ""},
+    },
+    {
+        "alias": "dew_point",
+        "zarr_index": HRRR["dew"],
+        "absolute_tolerance": 0.1,
+        "selector": {"name": "DPT", "level": "2 m above ground", "info": ""},
+    },
+    {
+        "alias": "wind_gust",
+        "zarr_index": HRRR["gust"],
+        "absolute_tolerance": 0.1,
+        "selector": {"name": "GUST", "level": "surface", "info": ""},
+    },
+    {
+        "alias": "visibility",
+        "zarr_index": HRRR["vis"],
+        "absolute_tolerance": 100.0,
+        "selector": {"name": "VIS", "level": "surface", "info": ""},
+    },
+)
 
 
 def _build_pythonpath(env: dict[str, str]) -> str:
@@ -23,15 +61,114 @@ def _build_pythonpath(env: dict[str, str]) -> str:
     return repo_root if not existing_path else repo_root + os.pathsep + existing_path
 
 
-@pytest.mark.skipif(
-    os.getenv(LOCAL_TEST_ENV_VAR) != "1",
-    reason=(
-        "HRRR_6H live ingest test requires a local wgrib2-enabled environment; "
-        f"set {LOCAL_TEST_ENV_VAR}=1 to run it"
-    ),
-)
-def test_hrrr_6h_ingest_produces_zarr():
-    """Run the live HRRR_6H ingest script and verify it writes a readable zarr."""
+def _format_utc(value) -> str:
+    """Format a datetime-like value as the UTC representation GribStream expects."""
+    if hasattr(value, "to_pydatetime"):
+        value = value.to_pydatetime()
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=datetime.UTC)
+    return value.astimezone(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _hrrr_grid_point(lat: float, lon: float) -> tuple[float, float, int, int]:
+    """Return the nearest HRRR grid point and its array indices."""
+    grid_lat, grid_lon, x_index, y_index = lambertGridMatch(
+        math.radians(262.5),
+        math.radians(38.5),
+        math.radians(38.5),
+        6371229,
+        lat,
+        lon % 360,
+        -2697500,
+        -1587300,
+        3000,
+    )
+    normalized_lon = ((grid_lon + 180) % 360) - 180
+    return grid_lat, normalized_lon, x_index, y_index
+
+
+def _fetch_gribstream_hrrr_run(
+    api_key: str, run_time, lat: float, lon: float
+) -> list[dict]:
+    """Fetch the HRRR fields used to validate one ingested forecast hour."""
+    lead_time = f"{GRIBSTREAM_COMPARISON_LEAD_HOURS}h"
+    payload = {
+        "timesList": [_format_utc(run_time)],
+        "minLeadTime": lead_time,
+        "maxLeadTime": lead_time,
+        "coordinates": [{"lat": lat, "lon": lon}],
+        "variables": [
+            {**variable["selector"], "alias": variable["alias"]}
+            for variable in GRIBSTREAM_VARIABLES
+        ],
+    }
+    request = Request(
+        GRIBSTREAM_HRRR_RUNS_URL,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urlopen(request, timeout=30) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def test_gribstream_request_pins_hrrr_run_and_lead_time(monkeypatch):
+    """Build the documented GribStream request without making a network call."""
+    captured = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+        def read(self):
+            return b'[{"temperature": 280.0}]'
+
+    def fake_urlopen(request, timeout):
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr("tests.test_hrrr_6h_ingest.urlopen", fake_urlopen)
+    run_time = datetime.datetime(2026, 9, 9, 6, tzinfo=datetime.UTC)
+
+    rows = _fetch_gribstream_hrrr_run("test-token", run_time, 40.0, -105.0)
+
+    assert rows == [{"temperature": 280.0}]
+    assert captured["timeout"] == 30
+    request = captured["request"]
+    assert request.full_url == GRIBSTREAM_HRRR_RUNS_URL
+    assert request.method == "POST"
+    assert request.get_header("Authorization") == "Bearer test-token"
+    assert request.get_header("Accept") == "application/json"
+    payload = json.loads(request.data)
+    assert payload["timesList"] == ["2026-09-09T06:00:00Z"]
+    assert payload["minLeadTime"] == "18h"
+    assert payload["maxLeadTime"] == "18h"
+    assert payload["coordinates"] == [{"lat": 40.0, "lon": -105.0}]
+    assert [variable["alias"] for variable in payload["variables"]] == [
+        "temperature",
+        "dew_point",
+        "wind_gust",
+        "visibility",
+    ]
+
+
+@pytest.fixture(scope="module")
+def hrrr_6h_ingest_output():
+    """Run HRRR_6H ingest once and retain its output for module tests."""
+    if os.getenv(LOCAL_TEST_ENV_VAR) != "1":
+        pytest.skip(
+            "HRRR_6H live ingest test requires a local wgrib2-enabled environment; "
+            f"set {LOCAL_TEST_ENV_VAR}=1 to run it"
+        )
+
     with tempfile.TemporaryDirectory() as tmpdir:
         env = os.environ.copy()
         env["forecast_process_dir"] = os.path.join(tmpdir, "HRRR_6H")
@@ -60,29 +197,85 @@ def test_hrrr_6h_ingest_produces_zarr():
         zarr_path = output_root / "HRRR_6H.zarr"
         time_pickle_path = output_root / "HRRR_6H.time.pickle"
 
-        assert zarr_path.exists(), (
-            f"Expected zarr output at {zarr_path}\n"
-            f"STDOUT:\n{result.stdout}\n"
-            f"STDERR:\n{result.stderr}"
-        )
-        assert time_pickle_path.exists(), (
-            f"Expected timestamp pickle at {time_pickle_path}\n"
-            f"STDOUT:\n{result.stdout}\n"
-            f"STDERR:\n{result.stderr}"
-        )
+        yield zarr_path, time_pickle_path, result
 
-        zarr_array = zarr.open(str(zarr_path), mode="r")
 
-        assert isinstance(zarr_array, zarr.Array), (
-            f"Expected a zarr array at {zarr_path}, got {type(zarr_array).__name__}"
+def test_hrrr_6h_ingest_produces_zarr(hrrr_6h_ingest_output):
+    """Verify the live HRRR_6H ingest writes a readable Zarr store."""
+    zarr_path, time_pickle_path, result = hrrr_6h_ingest_output
+
+    assert zarr_path.exists(), (
+        f"Expected zarr output at {zarr_path}\n"
+        f"STDOUT:\n{result.stdout}\n"
+        f"STDERR:\n{result.stderr}"
+    )
+    assert time_pickle_path.exists(), (
+        f"Expected timestamp pickle at {time_pickle_path}\n"
+        f"STDOUT:\n{result.stdout}\n"
+        f"STDERR:\n{result.stderr}"
+    )
+
+    zarr_array = zarr.open(str(zarr_path), mode="r")
+
+    assert isinstance(zarr_array, zarr.Array), (
+        f"Expected a zarr array at {zarr_path}, got {type(zarr_array).__name__}"
+    )
+    assert zarr_array.ndim == 4, f"Expected 4D zarr output, got {zarr_array.ndim}D"
+    assert zarr_array.shape[0] == EXPECTED_VAR_COUNT, (
+        f"Expected {EXPECTED_VAR_COUNT} variables, got shape {zarr_array.shape}"
+    )
+    assert zarr_array.shape[1] > 0, (
+        f"Expected time dimension > 0, got {zarr_array.shape}"
+    )
+    assert zarr_array.shape[2] > 0 and zarr_array.shape[3] > 0, (
+        f"Expected non-empty spatial dimensions, got {zarr_array.shape}"
+    )
+
+
+@pytest.mark.skipif(
+    not os.getenv(GRIBSTREAM_API_KEY_ENV_VAR),
+    reason=f"set {GRIBSTREAM_API_KEY_ENV_VAR} to run the GribStream comparison",
+)
+def test_hrrr_6h_ingest_matches_gribstream(hrrr_6h_ingest_output):
+    """Compare selected ingested HRRR fields with the matching GribStream run."""
+    zarr_path, time_pickle_path, _ = hrrr_6h_ingest_output
+    with time_pickle_path.open("rb") as file:
+        run_time = pickle.load(file)
+
+    grid_lat, grid_lon, x_index, y_index = _hrrr_grid_point(
+        *GRIBSTREAM_COMPARISON_LOCATION
+    )
+    try:
+        rows = _fetch_gribstream_hrrr_run(
+            os.environ[GRIBSTREAM_API_KEY_ENV_VAR],
+            run_time,
+            grid_lat,
+            grid_lon,
         )
-        assert zarr_array.ndim == 4, f"Expected 4D zarr output, got {zarr_array.ndim}D"
-        assert zarr_array.shape[0] == EXPECTED_VAR_COUNT, (
-            f"Expected {EXPECTED_VAR_COUNT} variables, got shape {zarr_array.shape}"
-        )
-        assert zarr_array.shape[1] > 0, (
-            f"Expected time dimension > 0, got {zarr_array.shape}"
-        )
-        assert zarr_array.shape[2] > 0 and zarr_array.shape[3] > 0, (
-            f"Expected non-empty spatial dimensions, got {zarr_array.shape}"
-        )
+    except HTTPError as exc:
+        if exc.code in {429, 503, 504}:
+            pytest.skip(f"GribStream temporarily unavailable: HTTP {exc.code}")
+        pytest.fail(f"GribStream request failed: HTTP {exc.code}")
+    except URLError as exc:
+        pytest.skip(f"Could not reach GribStream: {exc.reason}")
+
+    assert len(rows) == 1, (
+        "Expected one GribStream row for HRRR run "
+        f"{_format_utc(run_time)} at lead {GRIBSTREAM_COMPARISON_LEAD_HOURS}h, "
+        f"got {len(rows)}"
+    )
+    row = rows[0]
+    expected_valid_time = run_time + datetime.timedelta(
+        hours=GRIBSTREAM_COMPARISON_LEAD_HOURS
+    )
+    assert row["forecasted_at"] == _format_utc(run_time)
+    assert row["forecasted_time"] == _format_utc(expected_valid_time)
+
+    zarr_array = zarr.open(str(zarr_path), mode="r")
+    for variable in GRIBSTREAM_VARIABLES:
+        local_value = float(zarr_array[variable["zarr_index"], 0, y_index, x_index])
+        assert local_value == pytest.approx(
+            row[variable["alias"]],
+            abs=variable["absolute_tolerance"],
+            rel=1e-4,
+        ), variable["alias"]

--- a/tests/test_rtma_ingest.py
+++ b/tests/test_rtma_ingest.py
@@ -1,79 +1,310 @@
 """Test for RTMA-RU ingest script functionality."""
 
 import ast
+import datetime
+import json
+import math
 import os
+import pickle
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 import pytest
+import zarr
+
+from API.constants.grid_const import (
+    RTMA_RU_AXIS,
+    RTMA_RU_CENTRAL_LAT,
+    RTMA_RU_CENTRAL_LONG,
+    RTMA_RU_DELTA,
+    RTMA_RU_MIN_X,
+    RTMA_RU_MIN_Y,
+    RTMA_RU_PARALLEL,
+)
+from API.constants.model_const import RTMA_RU
+from API.constants.shared_const import INGEST_VERSION_STR
+from API.utils.geo import lambertGridMatch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "API" / "RTMA-RU_Local_Ingest.py"
+EXPECTED_VAR_COUNT = 10
+GRIBSTREAM_API_KEY_ENV_VAR = "GRIBSTREAM_API_KEY"
+GRIBSTREAM_RTMA_RU_RUNS_URL = "https://gribstream.com/api/v2/rtmaru/runs"
+GRIBSTREAM_COMPARISON_LOCATION = (40.0, -105.0)
+GRIBSTREAM_VARIABLES = (
+    {
+        "alias": "temperature",
+        "zarr_index": RTMA_RU["temp"],
+        "absolute_tolerance": 0.1,
+        "selector": {"name": "TMP", "level": "2 m above ground", "info": ""},
+    },
+    {
+        "alias": "dew_point",
+        "zarr_index": RTMA_RU["dew"],
+        "absolute_tolerance": 0.1,
+        "selector": {"name": "DPT", "level": "2 m above ground", "info": ""},
+    },
+    {
+        "alias": "wind_gust",
+        "zarr_index": RTMA_RU["gust"],
+        "absolute_tolerance": 0.1,
+        "selector": {
+            "name": "GUST",
+            "level": "10 m above ground",
+            "info": "",
+        },
+    },
+    {
+        "alias": "visibility",
+        "zarr_index": RTMA_RU["vis"],
+        "absolute_tolerance": 100.0,
+        "selector": {"name": "VIS", "level": "surface", "info": ""},
+    },
+    {
+        "alias": "pressure",
+        "zarr_index": RTMA_RU["pressure"],
+        "absolute_tolerance": 10.0,
+        "selector": {"name": "PRES", "level": "surface", "info": ""},
+    },
+    {
+        "alias": "cloud_cover",
+        "zarr_index": RTMA_RU["cloud"],
+        "absolute_tolerance": 1.0,
+        "selector": {
+            "name": "TCDC",
+            "level": "entire atmosphere (considered as a single layer)",
+            "info": "",
+        },
+    },
+)
 
 
-def test_rtma_script_runs():
-    """Test that RTMA-RU_Local_Ingest.py runs successfully.
+def _build_pythonpath(env: dict[str, str]) -> str:
+    existing_path = env.get("PYTHONPATH", "")
+    repo_root = str(REPO_ROOT)
+    return repo_root if not existing_path else repo_root + os.pathsep + existing_path
 
-    This test actually executes the script with appropriate environment variables
-    to ensure it can run without errors. The script will download real RTMA data
-    and process it.
-    """
-    rtma_script_path = (
-        Path(__file__).resolve().parents[1] / "API" / "RTMA-RU_Local_Ingest.py"
+
+def _format_utc(value) -> str:
+    """Format a datetime-like value as the UTC representation GribStream expects."""
+    if hasattr(value, "to_pydatetime"):
+        value = value.to_pydatetime()
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=datetime.UTC)
+    return value.astimezone(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _rtma_ru_grid_point(lat: float, lon: float) -> tuple[float, float, int, int]:
+    """Return the nearest RTMA-RU grid point and its array indices."""
+    grid_lat, grid_lon, x_index, y_index = lambertGridMatch(
+        math.radians(RTMA_RU_CENTRAL_LONG),
+        math.radians(RTMA_RU_CENTRAL_LAT),
+        math.radians(RTMA_RU_PARALLEL),
+        RTMA_RU_AXIS,
+        lat,
+        lon % 360,
+        RTMA_RU_MIN_X,
+        RTMA_RU_MIN_Y,
+        RTMA_RU_DELTA,
     )
+    normalized_lon = ((grid_lon + 180) % 360) - 180
+    return grid_lat, normalized_lon, x_index, y_index
 
-    # Create a temporary directory for the test
+
+def _fetch_gribstream_rtma_ru_run(
+    api_key: str, run_time, lat: float, lon: float
+) -> list[dict]:
+    """Fetch fields for one exact RTMA-RU analysis run."""
+    payload = {
+        "timesList": [_format_utc(run_time)],
+        "coordinates": [{"lat": lat, "lon": lon}],
+        "variables": [
+            {**variable["selector"], "alias": variable["alias"]}
+            for variable in GRIBSTREAM_VARIABLES
+        ],
+    }
+    request = Request(
+        GRIBSTREAM_RTMA_RU_RUNS_URL,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urlopen(request, timeout=30) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+@pytest.fixture(scope="module")
+def rtma_ru_ingest_output():
+    """Run RTMA-RU ingest once and retain its output for module tests."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        # Set up environment variables for the script
         env = os.environ.copy()
         env["forecast_process_dir"] = os.path.join(tmpdir, "RTMA_RU")
         env["forecast_path"] = os.path.join(tmpdir, "Prod", "RTMA_RU")
         env["save_type"] = "Download"
         env["AWS_KEY"] = ""
         env["AWS_SECRET"] = ""
-        # Add the repository root to PYTHONPATH so API module can be imported
-        repo_root = str(Path(__file__).resolve().parents[1])
-        env["PYTHONPATH"] = repo_root + os.pathsep + env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = _build_pythonpath(env)
 
-        # Run the script
         result = subprocess.run(
-            [sys.executable, str(rtma_script_path)],
+            [sys.executable, str(SCRIPT_PATH)],
             env=env,
             capture_output=True,
             text=True,
-            timeout=600,  # 10 minute timeout
+            timeout=600,
             check=False,
         )
 
-        # Print stdout and stderr for debugging if needed
-        print("STDOUT:\n", result.stdout)
-        print("STDERR:\n", result.stderr)
-
-        # The script should either complete successfully (exit code 0)
-        # or exit early if no update is needed (also exit code 0)
         assert result.returncode == 0, (
-            f"Script failed with exit code {result.returncode}\n"
+            f"RTMA-RU ingest failed with exit code {result.returncode}\n"
             f"STDOUT:\n{result.stdout}\n"
             f"STDERR:\n{result.stderr}"
         )
 
+        output_root = Path(env["forecast_path"]) / INGEST_VERSION_STR
+        zarr_path = output_root / "RTMA_RU.zarr"
+        time_pickle_path = output_root / "RTMA_RU.time.pickle"
+
+        yield zarr_path, time_pickle_path, result
+
+
+def test_rtma_ingest_produces_zarr(rtma_ru_ingest_output):
+    """Verify the live RTMA-RU ingest writes a readable Zarr store."""
+    zarr_path, time_pickle_path, result = rtma_ru_ingest_output
+
+    assert zarr_path.exists(), (
+        f"Expected zarr output at {zarr_path}\n"
+        f"STDOUT:\n{result.stdout}\n"
+        f"STDERR:\n{result.stderr}"
+    )
+    assert time_pickle_path.exists(), (
+        f"Expected timestamp pickle at {time_pickle_path}\n"
+        f"STDOUT:\n{result.stdout}\n"
+        f"STDERR:\n{result.stderr}"
+    )
+
+    zarr_array = zarr.open(str(zarr_path), mode="r")
+
+    assert isinstance(zarr_array, zarr.Array), (
+        f"Expected a zarr array at {zarr_path}, got {type(zarr_array).__name__}"
+    )
+    assert zarr_array.ndim == 4, f"Expected 4D zarr output, got {zarr_array.ndim}D"
+    assert zarr_array.shape[0] == EXPECTED_VAR_COUNT, (
+        f"Expected {EXPECTED_VAR_COUNT} variables, got shape {zarr_array.shape}"
+    )
+    assert zarr_array.shape[1] == 1, (
+        f"Expected one analysis time, got shape {zarr_array.shape}"
+    )
+    assert zarr_array.shape[2] > 0 and zarr_array.shape[3] > 0, (
+        f"Expected non-empty spatial dimensions, got {zarr_array.shape}"
+    )
+
+
+def test_gribstream_request_pins_rtma_ru_run(monkeypatch):
+    """Build the documented GribStream request without making a network call."""
+    captured = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+        def read(self):
+            return b'[{"temperature": 280.0}]'
+
+    def fake_urlopen(request, timeout):
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr("tests.test_rtma_ingest.urlopen", fake_urlopen)
+    run_time = datetime.datetime(2026, 9, 9, 13, 30, tzinfo=datetime.UTC)
+
+    rows = _fetch_gribstream_rtma_ru_run("test-token", run_time, 40.0, -105.0)
+
+    assert rows == [{"temperature": 280.0}]
+    assert captured["timeout"] == 30
+    request = captured["request"]
+    assert request.full_url == GRIBSTREAM_RTMA_RU_RUNS_URL
+    assert request.method == "POST"
+    assert request.get_header("Authorization") == "Bearer test-token"
+    assert request.get_header("Accept") == "application/json"
+    payload = json.loads(request.data)
+    assert payload["timesList"] == ["2026-09-09T13:30:00Z"]
+    assert payload["coordinates"] == [{"lat": 40.0, "lon": -105.0}]
+    assert [variable["alias"] for variable in payload["variables"]] == [
+        "temperature",
+        "dew_point",
+        "wind_gust",
+        "visibility",
+        "pressure",
+        "cloud_cover",
+    ]
+
+
+@pytest.mark.skipif(
+    not os.getenv(GRIBSTREAM_API_KEY_ENV_VAR),
+    reason=f"set {GRIBSTREAM_API_KEY_ENV_VAR} to run the GribStream comparison",
+)
+def test_rtma_ru_ingest_matches_gribstream(rtma_ru_ingest_output):
+    """Compare selected ingested RTMA-RU fields with the matching GribStream run."""
+    zarr_path, time_pickle_path, _ = rtma_ru_ingest_output
+    with time_pickle_path.open("rb") as file:
+        run_time = pickle.load(file)
+
+    grid_lat, grid_lon, x_index, y_index = _rtma_ru_grid_point(
+        *GRIBSTREAM_COMPARISON_LOCATION
+    )
+    try:
+        rows = _fetch_gribstream_rtma_ru_run(
+            os.environ[GRIBSTREAM_API_KEY_ENV_VAR],
+            run_time,
+            grid_lat,
+            grid_lon,
+        )
+    except HTTPError as exc:
+        if exc.code in {429, 503, 504}:
+            pytest.skip(f"GribStream temporarily unavailable: HTTP {exc.code}")
+        pytest.fail(f"GribStream request failed: HTTP {exc.code}")
+    except URLError as exc:
+        pytest.skip(f"Could not reach GribStream: {exc.reason}")
+
+    assert len(rows) == 1, (
+        f"Expected one GribStream row for RTMA-RU run {_format_utc(run_time)}, "
+        f"got {len(rows)}"
+    )
+    row = rows[0]
+    assert row["forecasted_at"] == _format_utc(run_time)
+
+    zarr_array = zarr.open(str(zarr_path), mode="r")
+    for variable in GRIBSTREAM_VARIABLES:
+        local_value = float(zarr_array[variable["zarr_index"], 0, y_index, x_index])
+        assert local_value == pytest.approx(
+            row[variable["alias"]],
+            abs=variable["absolute_tolerance"],
+            rel=1e-4,
+        ), variable["alias"]
+
 
 def test_rtma_script_exists():
     """Test that RTMA-RU_Local_Ingest.py exists."""
-    rtma_script_path = (
-        Path(__file__).resolve().parents[1] / "API" / "RTMA-RU_Local_Ingest.py"
-    )
-    assert rtma_script_path.exists(), f"RTMA script not found at {rtma_script_path}"
-    assert rtma_script_path.is_file(), "RTMA script is not a file"
+    assert SCRIPT_PATH.exists(), f"RTMA script not found at {SCRIPT_PATH}"
+    assert SCRIPT_PATH.is_file(), "RTMA script is not a file"
 
 
 def test_rtma_script_is_valid_python():
     """Test that RTMA-RU_Local_Ingest.py is valid Python syntax."""
-    rtma_script_path = (
-        Path(__file__).resolve().parents[1] / "API" / "RTMA-RU_Local_Ingest.py"
-    )
-
     # Read the script content
-    script_content = rtma_script_path.read_text()
+    script_content = SCRIPT_PATH.read_text()
 
     # Try to parse it as Python code
     try:
@@ -84,12 +315,8 @@ def test_rtma_script_is_valid_python():
 
 def test_rtma_script_has_required_imports():
     """Test that the RTMA script has all required imports."""
-    rtma_script_path = (
-        Path(__file__).resolve().parents[1] / "API" / "RTMA-RU_Local_Ingest.py"
-    )
-
     # Read the script content
-    script_content = rtma_script_path.read_text()
+    script_content = SCRIPT_PATH.read_text()
 
     # Check for required imports
     required_imports = [
@@ -108,12 +335,8 @@ def test_rtma_script_has_required_imports():
 
 def test_rtma_script_has_required_components():
     """Test that the RTMA script contains expected components."""
-    rtma_script_path = (
-        Path(__file__).resolve().parents[1] / "API" / "RTMA-RU_Local_Ingest.py"
-    )
-
     # Read the script content
-    script_content = rtma_script_path.read_text()
+    script_content = SCRIPT_PATH.read_text()
 
     # Check for key processing steps
     assert "zarr_vars" in script_content, "Missing zarr_vars definition"
@@ -133,13 +356,9 @@ def test_rtma_script_has_required_components():
 
 def test_rtma_script_python_check():
     """Test that the RTMA script can be checked with python -m py_compile."""
-    rtma_script_path = (
-        Path(__file__).resolve().parents[1] / "API" / "RTMA-RU_Local_Ingest.py"
-    )
-
     # Use py_compile to check if the script compiles
     result = subprocess.run(
-        [sys.executable, "-m", "py_compile", str(rtma_script_path)],
+        [sys.executable, "-m", "py_compile", str(SCRIPT_PATH)],
         capture_output=True,
         text=True,
         check=False,

--- a/tests/test_rtma_ingest.py
+++ b/tests/test_rtma_ingest.py
@@ -251,6 +251,33 @@ def test_gribstream_request_pins_rtma_ru_run(monkeypatch):
     ]
 
 
+def test_projection_import_does_not_require_timezone_dependencies():
+    """The ingest comparison should not require API-only timezone packages."""
+    source = """
+import builtins
+
+real_import = builtins.__import__
+
+def reject_timezone_imports(name, *args, **kwargs):
+    if name.split('.', 1)[0] in {'pytz', 'timezonefinder'}:
+        raise ModuleNotFoundError(name)
+    return real_import(name, *args, **kwargs)
+
+builtins.__import__ = reject_timezone_imports
+from API.utils.geo import lambertGridMatch
+assert callable(lambertGridMatch)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", source],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 @pytest.mark.skipif(
     not os.getenv(GRIBSTREAM_API_KEY_ENV_VAR),
     reason=f"set {GRIBSTREAM_API_KEY_ENV_VAR} to run the GribStream comparison",

--- a/tests/test_zip_sync.py
+++ b/tests/test_zip_sync.py
@@ -1,0 +1,34 @@
+"""Regression tests for the local Zarr ZIP synchronization script."""
+
+import re
+import subprocess
+from pathlib import Path
+
+ZIP_SYNC_PATH = Path(__file__).resolve().parents[1] / "API" / "zip_sync.sh"
+CMC_MODELS = {"GDPS", "GEPS", "HRDPS", "RAQDPS", "REPS"}
+
+
+def _configured_models() -> set[str]:
+    source = ZIP_SYNC_PATH.read_text(encoding="utf-8")
+    match = re.search(
+        r'^MODELS="\n(?P<models>.*?)\n"$', source, flags=re.MULTILINE | re.DOTALL
+    )
+    assert match is not None, "MODELS block not found in zip_sync.sh"
+    return set(match.group("models").split())
+
+
+def test_zip_sync_includes_cmc_models():
+    """All CMC forecast archives should be included in the sync allowlist."""
+    assert CMC_MODELS <= _configured_models()
+
+
+def test_zip_sync_has_valid_shell_syntax():
+    """The synchronization script should remain valid POSIX shell syntax."""
+    result = subprocess.run(
+        ["sh", "-n", str(ZIP_SYNC_PATH)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Describe the change
Add in the new CMC models to the zip syncing as well as some new tests using a gribstream dataset

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [ ] Code builds locally. **Your pull request won't be merged unless tests pass**
- [ ] Code has been formatted using ruff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for synchronizing GDPS, GEPS, HRDPS, and REPS model archives.
  - Added optional GribStream API key configuration for live ingest comparisons.

- **Tests**
  - Expanded ingest validation for HRRR and RTMA data using live comparison checks.
  - Added coverage to verify synchronization model coverage and shell-script validity.
  - Updated production comparison checks for the new timemachine endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->