### PR TITLE
fix: Keep double line spacing in US alerts

### DIFF
--- a/API/alerts.py
+++ b/API/alerts.py
@@ -238,5 +238,4 @@ def _format_alert_description(alert_description: str) -> str:
     Returns:
         The formatted alert description string.
     """
-    formatted_text = re.sub(r"(?<!\n)\n(?!\n)", " ", alert_description)
-    return re.sub(r"\n\n", "\n", formatted_text)
+    return re.sub(r"(?<!\n)\n(?!\n)", " ", alert_description)


### PR DESCRIPTION
## Describe the change
Keeps consistency between the US and non-US alerts as the double spacing is much easier to read than the single spacing.

## Type of change

- [ ] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [x] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes https://github.com/Pirate-Weather/pirateweather/issues/676
- [ ] Code builds locally. **Your pull request won't be merged unless tests pass**
- [ ] Code has been formatted using ruff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Alert descriptions now preserve paragraph breaks while still formatting single line breaks as spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->