### PR TITLE
Fix UV and Ozone source priority in Canada

### DIFF
--- a/API/current/metrics.py
+++ b/API/current/metrics.py
@@ -1084,7 +1084,14 @@ def _get_cloud(
     return clipLog(val, CLIP_CLOUD["min"], CLIP_CLOUD["max"], "Cloud Current")
 
 
-def _get_uv(sourceList, model_data, state: InterpolationState):
+def _get_uv(
+    sourceList,
+    model_data,
+    state: InterpolationState,
+    lat,
+    lon,
+    prioritize_ai_models=False,
+):
     """
     Get current UV index from available sources.
 
@@ -1092,43 +1099,54 @@ def _get_uv(sourceList, model_data, state: InterpolationState):
         sourceList: List of available sources.
         model_data: Dictionary of model data.
         state: Interpolation state.
+        lat: Latitude.
+        lon: Longitude.
+        prioritize_ai_models: Whether to prioritize AI model sources.
 
     Returns:
         Current UV index.
     """
-    if "gfs" in sourceList:
-        return clipLog(
-            (
-                model_data["GFS_Merged"][state.idx1, GFS["uv"]] * state.fac1
-                + model_data["GFS_Merged"][state.idx2, GFS["uv"]] * state.fac2
-            )
-            * 18.9
-            * 0.025,
-            CLIP_UV["min"],
-            CLIP_UV["max"],
-            "UV Current",
-        )
-    elif "era5" in sourceList:
-        return clipLog(
-            (
-                model_data["ERA5_MERGED"][
-                    state.idx1, ERA5["downward_uv_radiation_at_the_surface"]
-                ]
-                * state.fac1
-                + model_data["ERA5_MERGED"][
-                    state.idx2, ERA5["downward_uv_radiation_at_the_surface"]
-                ]
-                * state.fac2
-            )
-            / 3600
-            * 40
-            * 0.0025,
-            CLIP_UV["min"],
-            CLIP_UV["max"],
-            "UV Current",
-        )
-    else:
-        return MISSING_DATA
+    source_map = {
+        "hrdps": (
+            lambda: "hrdps" in sourceList,
+            lambda: _interp_scalar(model_data["HRDPS_Merged"], HRDPS["uv"], state),
+        ),
+        "gdps": (
+            lambda: "gdps" in sourceList,
+            lambda: _interp_scalar(model_data["GDPS_Merged"], GDPS["uv"], state),
+        ),
+        "gfs": (
+            lambda: "gfs" in sourceList,
+            lambda: (
+                _interp_scalar(model_data["GFS_Merged"], GFS["uv"], state)
+                * 18.9
+                * 0.025
+            ),
+        ),
+        "era5": (
+            lambda: "era5" in sourceList,
+            lambda: (
+                _interp_scalar(
+                    model_data["ERA5_MERGED"],
+                    ERA5["downward_uv_radiation_at_the_surface"],
+                    state,
+                )
+                / 3600
+                * 40
+                * 0.0025
+            ),
+        ),
+    }
+
+    strategies = _build_source_strategies(
+        source_map,
+        lat,
+        lon,
+        has_ecmwf=False,
+        prioritize_ai_models=prioritize_ai_models,
+    )
+    val = _select_value(strategies, default=MISSING_DATA)
+    return clipLog(val, CLIP_UV["min"], CLIP_UV["max"], "UV Current")
 
 
 def _get_station_pressure(sourceList, model_data, state: InterpolationState):
@@ -1238,7 +1256,14 @@ def _get_vis(
     return np.clip(val, CLIP_VIS["min"], CLIP_VIS["max"])
 
 
-def _get_ozone(sourceList, model_data, state: InterpolationState):
+def _get_ozone(
+    sourceList,
+    model_data,
+    state: InterpolationState,
+    lat,
+    lon,
+    prioritize_ai_models=False,
+):
     """
     Get current ozone from available sources.
 
@@ -1246,30 +1271,43 @@ def _get_ozone(sourceList, model_data, state: InterpolationState):
         sourceList: List of available sources.
         model_data: Dictionary of model data.
         state: Interpolation state.
+        lat: Latitude.
+        lon: Longitude.
+        prioritize_ai_models: Whether to prioritize AI model sources.
 
     Returns:
         Current ozone.
     """
-    val = _select_value(
-        [
-            (
-                lambda: "gfs" in sourceList,
-                lambda: _interp_scalar(model_data["GFS_Merged"], GFS["ozone"], state),
+    source_map = {
+        "gdps": (
+            lambda: "gdps" in sourceList,
+            lambda: _interp_scalar(model_data["GDPS_Merged"], GDPS["ozone"], state),
+        ),
+        "gfs": (
+            lambda: "gfs" in sourceList,
+            lambda: _interp_scalar(model_data["GFS_Merged"], GFS["ozone"], state),
+        ),
+        "era5": (
+            lambda: "era5" in sourceList,
+            lambda: (
+                _interp_scalar(
+                    model_data["ERA5_MERGED"],
+                    ERA5["total_column_ozone"],
+                    state,
+                )
+                * 46696
             ),
-            (
-                lambda: "era5" in sourceList,
-                lambda: (
-                    _interp_scalar(
-                        model_data["ERA5_MERGED"],
-                        ERA5["total_column_ozone"],
-                        state,
-                    )
-                    * 46696
-                ),
-            ),
-        ],
-        default=MISSING_DATA,
+        ),
+    }
+
+    strategies = _build_source_strategies(
+        source_map,
+        lat,
+        lon,
+        has_ecmwf=False,
+        prioritize_ai_models=prioritize_ai_models,
     )
+    val = _select_value(strategies, default=MISSING_DATA)
     return clipLog(val, CLIP_OZONE["min"], CLIP_OZONE["max"], "Ozone Current")
 
 
@@ -1718,14 +1756,18 @@ def build_current_section(
     InterPcurrent[DATA_CURRENT["cloud"]] = _get_cloud(
         sourceList, model_data, state, lat, lon_IN, prioritize_ai_models
     )
-    InterPcurrent[DATA_CURRENT["uv"]] = _get_uv(sourceList, model_data, state)
+    InterPcurrent[DATA_CURRENT["uv"]] = _get_uv(
+        sourceList, model_data, state, lat, lon_IN, prioritize_ai_models
+    )
     InterPcurrent[DATA_CURRENT["station_pressure"]] = _get_station_pressure(
         sourceList, model_data, state
     )
     InterPcurrent[DATA_CURRENT["vis"]] = _get_vis(
         sourceList, model_data, state, lat, lon_IN, prioritize_ai_models
     )
-    InterPcurrent[DATA_CURRENT["ozone"]] = _get_ozone(sourceList, model_data, state)
+    InterPcurrent[DATA_CURRENT["ozone"]] = _get_ozone(
+        sourceList, model_data, state, lat, lon_IN, prioritize_ai_models
+    )
 
     (
         InterPcurrent[DATA_CURRENT["storm_dist"]],

--- a/API/data_inputs.py
+++ b/API/data_inputs.py
@@ -870,19 +870,26 @@ def prepare_data_inputs(
     )
 
     # --- uv_inputs ---
-    uv_inputs = _stack_fields(
+    uv_inputs = _stack_with_priority(
         num_hours,
-        (gfs_merged[:, GFS["uv"]] * 18.9 * 0.025) if gfs_merged is not None else None,
-        (hrdps_merged[:, HRDPS["uv"]]) if hrdps_merged is not None else None,
-        (gdps_merged[:, GDPS["uv"]]) if gdps_merged is not None else None,
-        (
-            era5_merged[:, ERA5["downward_uv_radiation_at_the_surface"]]
-            / 3600
-            * 40
-            * 0.0025
-        )
-        if era5_valid
-        else None,
+        lat,
+        lon,
+        source_data={
+            "hrdps": hrdps_merged[:, HRDPS["uv"]] if hrdps_merged is not None else None,
+            "gdps": gdps_merged[:, GDPS["uv"]] if gdps_merged is not None else None,
+            "gfs": (gfs_merged[:, GFS["uv"]] * 18.9 * 0.025)
+            if gfs_merged is not None
+            else None,
+            "era5": (
+                era5_merged[:, ERA5["downward_uv_radiation_at_the_surface"]]
+                / 3600
+                * 40
+                * 0.0025
+            )
+            if era5_valid
+            else None,
+        },
+        prioritize_ai_models=prioritize_ai_models,
     )
 
     # --- vis_inputs ---
@@ -907,11 +914,18 @@ def prepare_data_inputs(
     )
 
     # --- ozone_inputs ---
-    ozone_inputs = _stack_fields(
+    ozone_inputs = _stack_with_priority(
         num_hours,
-        gfs_merged[:, GFS["ozone"]] if gfs_merged is not None else None,
-        gdps_merged[:, GDPS["ozone"]] if gdps_merged is not None else None,
-        era5_merged[:, ERA5["total_column_ozone"]] * 46696 if era5_valid else None,
+        lat,
+        lon,
+        source_data={
+            "gdps": gdps_merged[:, GDPS["ozone"]] if gdps_merged is not None else None,
+            "gfs": gfs_merged[:, GFS["ozone"]] if gfs_merged is not None else None,
+            "era5": era5_merged[:, ERA5["total_column_ozone"]] * 46696
+            if era5_valid
+            else None,
+        },
+        prioritize_ai_models=prioritize_ai_models,
     )
 
     # --- smoke_inputs ---

--- a/tests/test_current_refactor.py
+++ b/tests/test_current_refactor.py
@@ -4,13 +4,15 @@ import numpy as np
 
 from API.constants.aqi_const import compute_aqi_array
 from API.constants.forecast_const import DATA_CURRENT
-from API.constants.model_const import HRDPS, NBM
+from API.constants.model_const import GDPS, GFS, HRDPS, NBM
 from API.constants.shared_const import MISSING_DATA
 from API.current.metrics import (
     CurrentSection,
     InterpolationState,
     _get_fire,
+    _get_ozone,
     _get_temp,
+    _get_uv,
     build_current_section,
 )
 
@@ -34,6 +36,29 @@ def test_current_temperature_prefers_hrdps_over_nbm_in_canada():
     )
 
     assert value == 5.0
+
+
+def test_current_canada_prioritizes_canadian_uv_and_ozone_over_gfs():
+    hrdps = np.full((2, max(HRDPS.values()) + 1), np.nan)
+    gdps = np.full((2, max(GDPS.values()) + 1), np.nan)
+    gfs = np.full((2, max(GFS.values()) + 1), np.nan)
+    hrdps[:, HRDPS["uv"]] = 7.0
+    gdps[:, GDPS["uv"]] = 6.0
+    gdps[:, GDPS["ozone"]] = 350.0
+    gfs[:, GFS["uv"]] = 9.0 / (18.9 * 0.025)
+    gfs[:, GFS["ozone"]] = 300.0
+    model_data = {
+        "HRDPS_Merged": hrdps,
+        "GDPS_Merged": gdps,
+        "GFS_Merged": gfs,
+    }
+    state = InterpolationState(idx1=0, idx2=1, fac1=0.5, fac2=0.5)
+
+    uv = _get_uv(["gfs", "hrdps", "gdps"], model_data, state, 45.4215, -75.6972)
+    ozone = _get_ozone(["gfs", "hrdps", "gdps"], model_data, state, 45.4215, -75.6972)
+
+    assert uv == 7.0
+    assert ozone == 350.0
 
 
 def test_build_current_section_structure():

--- a/tests/test_north_america_priority.py
+++ b/tests/test_north_america_priority.py
@@ -3,7 +3,16 @@
 import numpy as np
 
 from API.constants.api_const import PRECIP_IDX
-from API.constants.model_const import DWD_MOSMIX, ECMWF, GDPS, GEFS, GEPS, GFS, NBM
+from API.constants.model_const import (
+    DWD_MOSMIX,
+    ECMWF,
+    GDPS,
+    GEFS,
+    GEPS,
+    GFS,
+    HRDPS,
+    NBM,
+)
 from API.current.metrics import _build_source_strategies
 from API.data_inputs import prepare_data_inputs
 from API.utils.geo import is_in_north_america
@@ -109,6 +118,39 @@ def test_hourly_us_uses_gdps_geps_after_gfs_gefs():
     assert np.all(inputs["temperature_inputs"][:, 1] == 20.0)
     assert np.all(inputs["prcipProbability_inputs"][:, 0] == 0.4)
     assert np.all(inputs["prcipProbability_inputs"][:, 1] == 0.7)
+
+
+def test_hourly_canada_prioritizes_canadian_uv_and_ozone_over_gfs():
+    num_hours = 3
+    gfs = np.full((num_hours, max(GFS.values()) + 1), np.nan)
+    hrdps = np.full((num_hours, max(HRDPS.values()) + 1), np.nan)
+    gdps = np.full((num_hours, max(GDPS.values()) + 1), np.nan)
+    gfs[:, GFS["uv"]] = 9.0 / (18.9 * 0.025)
+    gfs[:, GFS["ozone"]] = 300.0
+    hrdps[:, HRDPS["uv"]] = 7.0
+    gdps[:, GDPS["uv"]] = 6.0
+    gdps[:, GDPS["ozone"]] = 350.0
+
+    inputs = prepare_data_inputs(
+        source_list=["gfs", "hrdps", "gdps"],
+        nbm_merged=None,
+        nbm_fire_merged=None,
+        hrrr_merged=None,
+        dwd_mosmix_merged=None,
+        ecmwf_merged=None,
+        gefs_merged=None,
+        gfs_merged=gfs,
+        era5_merged=None,
+        extra_vars=[],
+        num_hours=num_hours,
+        lat=45.4215,
+        lon=-75.6972,
+        hrdps_merged=hrdps,
+        gdps_merged=gdps,
+    )
+
+    assert np.all(inputs["uv_inputs"][:, 0] == 7.0)
+    assert np.all(inputs["ozone_inputs"][:, 0] == 350.0)
 
 
 def test_ai_priority_applies_inside_canada():


### PR DESCRIPTION
## Describe the change
Small tweak to fix the source for the UV and ozone data in the Canada domain. Should pull from GDPS instead of GFS. Re: https://github.com/Pirate-Weather/pirateweather/issues/679 

## Type of change

- [X] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes https://github.com/Pirate-Weather/pirateweather/issues/679
- [ ] Code builds locally. **Your pull request won't be merged unless tests pass**
- [ ] Code has been formatted using ruff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - UV and ozone data now use location-based source prioritization.
  - Canadian locations prioritize Canadian weather models for UV and ozone data.
  - Added support for HRDPS and GDPS sources in relevant calculations.

- **Bug Fixes**
  - Improved source selection for UV and ozone values across different locations.
  - Ensured model data is correctly converted and prioritized in current and hourly forecasts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->