### PR TITLE
fix: Add REPS and GEPS to intensity block

### DIFF
--- a/API/data_inputs.py
+++ b/API/data_inputs.py
@@ -450,6 +450,22 @@ def prepare_data_inputs(
         "gfs": gfs_merged[:, GFS["intensity"]] * 3600
         if "gfs" in source_list and gfs_merged is not None
         else None,
+        "reps": (
+            reps_merged[:, REPS["rain"]]
+            + reps_merged[:, REPS["snow"]]
+            + reps_merged[:, REPS["ice"]]
+            + reps_merged[:, REPS["freezing_rain"]]
+        )
+        if "reps" in source_list and reps_merged is not None
+        else None,
+        "geps": (
+            geps_merged[:, GEPS["rain"]]
+            + geps_merged[:, GEPS["snow"]]
+            + geps_merged[:, GEPS["ice"]]
+            + geps_merged[:, GEPS["freezing_rain"]]
+        )
+        if "geps" in source_list and geps_merged is not None
+        else None,
     }
 
     era5_rain_intensity = None

--- a/API/minutely/builder.py
+++ b/API/minutely/builder.py
@@ -665,6 +665,7 @@ def _calculate_intensity(
     gefsMinuteInterpolation,
     gfsMinuteInterpolation,
     gdpsMinuteInterpolation,
+    repsMinuteInterpolation,
     gepsMinuteInterpolation,
     era5_MinuteInterpolation,
     lat,
@@ -748,8 +749,20 @@ def _calculate_intensity(
         refc_used = True
     elif "gdps" in source_list and gdpsMinuteInterpolation is not None:
         intensity = gdpsMinuteInterpolation[:, GDPS["intensity"]] * 3600
+    elif "reps" in source_list and gepsMinuteInterpolation is not None:
+        intensity = (
+            repsMinuteInterpolation[:, REPS["rain"]]
+            + repsMinuteInterpolation[:, REPS["snow"]]
+            + repsMinuteInterpolation[:, REPS["ice"]]
+            + repsMinuteInterpolation[:, REPS["freezing_rain"]]
+        )
     elif "geps" in source_list and gepsMinuteInterpolation is not None:
-        intensity = gepsMinuteInterpolation[:, GEPS["accum"]]
+        intensity = (
+            gepsMinuteInterpolation[:, GEPS["rain"]]
+            + gepsMinuteInterpolation[:, GEPS["snow"]]
+            + gepsMinuteInterpolation[:, GEPS["ice"]]
+            + gepsMinuteInterpolation[:, GEPS["freezing_rain"]]
+        )
     elif "era5" in source_list and era5_MinuteInterpolation is not None:
         intensity = (
             era5_MinuteInterpolation[
@@ -1132,6 +1145,7 @@ def build_minutely_block(
         gefsMinuteInterpolation,
         gfsMinuteInterpolation,
         gdpsMinuteInterpolation,
+        repsMinuteInterpolation,
         gepsMinuteInterpolation,
         era5_MinuteInterpolation,
         lat,

--- a/API/minutely/builder.py
+++ b/API/minutely/builder.py
@@ -483,6 +483,17 @@ def _process_geps_ptype(gepsMinuteInterpolation, InterTminute):
     _set_ptype_categories(mapped, InterTminute)
 
 
+def _process_reps_ptype(repsMinuteInterpolation, InterTminute):
+    """Process REPS ensemble precipitation component data."""
+    mapped = map_ensemble_precip_rates_to_ptype(
+        rain=repsMinuteInterpolation[:, REPS["rain"]],
+        ice=repsMinuteInterpolation[:, REPS["ice"]],
+        freezing_rain=repsMinuteInterpolation[:, REPS["freezing_rain"]],
+        snow=repsMinuteInterpolation[:, REPS["snow"]],
+    )
+    _set_ptype_categories(mapped, InterTminute)
+
+
 def _process_aigefs_ptype_with_temperature(
     aigefsMinuteInterpolation, gfsMinuteInterpolation, InterTminute
 ):
@@ -523,6 +534,7 @@ def _calculate_precip_type_probs(
     gefsMinuteInterpolation,
     gfsMinuteInterpolation,
     gdpsMinuteInterpolation,
+    repsMinuteInterpolation,
     gepsMinuteInterpolation,
     era5_MinuteInterpolation,
     lat,
@@ -540,6 +552,9 @@ def _calculate_precip_type_probs(
         ecmwfMinuteInterpolation: ECMWF interpolated data.
         gefsMinuteInterpolation: GEFS interpolated data.
         gfsMinuteInterpolation: GFS interpolated data.
+        gdpsMinuteInterpolation: GDPS interpolated data.
+        repsMinuteInterpolation: REPS interpolated data.
+        ecmwfMinuteInterpolation: ECMWF interpolated data.
         era5_MinuteInterpolation: ERA5 interpolated data.
         lat: Latitude of the location.
         lon: Longitude of the location.
@@ -619,6 +634,9 @@ def _calculate_precip_type_probs(
         if "gefs" in source_list and gefsMinuteInterpolation is not None:
             _process_gefs_ptype(gefsMinuteInterpolation, InterTminute)
             return InterTminute
+        if "reps" in source_list and repsMinuteInterpolation is not None:
+            _process_reps_ptype(repsMinuteInterpolation, InterTminute)
+            return InterTminute
         if "gdps" in source_list and gdpsMinuteInterpolation is not None:
             _process_gdps_ptype(gdpsMinuteInterpolation, InterTminute)
             return InterTminute
@@ -641,6 +659,9 @@ def _calculate_precip_type_probs(
             return InterTminute
         if "gefs" in source_list and gefsMinuteInterpolation is not None:
             _process_gefs_ptype(gefsMinuteInterpolation, InterTminute)
+            return InterTminute
+        if "reps" in source_list and repsMinuteInterpolation is not None:
+            _process_reps_ptype(repsMinuteInterpolation, InterTminute)
             return InterTminute
         if "gdps" in source_list and gdpsMinuteInterpolation is not None:
             _process_gdps_ptype(gdpsMinuteInterpolation, InterTminute)
@@ -749,7 +770,7 @@ def _calculate_intensity(
         refc_used = True
     elif "gdps" in source_list and gdpsMinuteInterpolation is not None:
         intensity = gdpsMinuteInterpolation[:, GDPS["intensity"]] * 3600
-    elif "reps" in source_list and gepsMinuteInterpolation is not None:
+    elif "reps" in source_list and repsMinuteInterpolation is not None:
         intensity = (
             repsMinuteInterpolation[:, REPS["rain"]]
             + repsMinuteInterpolation[:, REPS["snow"]]
@@ -1089,6 +1110,7 @@ def build_minutely_block(
         gfsMinuteInterpolation,
         gdpsMinuteInterpolation,
         gepsMinuteInterpolation,
+        repsMinuteInterpolation,
         era5_MinuteInterpolation,
         lat,
         lon,

--- a/API/request/grid_indexing.py
+++ b/API/request/grid_indexing.py
@@ -1273,8 +1273,8 @@ async def calculate_grid_indexing(
                     repsRunTime.astype(int), datetime.UTC
                 ).replace(tzinfo=None)
                 # Freshness check for REPS
-                # REPS has 84 hours of data so exclude if 59 hours stale
-                if (utc_time - timestamp_dt) > datetime.timedelta(hours=59):
+                # REPS has 72 hours of data so exclude if 51 hours stale
+                if (utc_time - timestamp_dt) > datetime.timedelta(hours=51):
                     dataOut_reps = False
                     repsRunTime = None
                     logger.warning("OLD REPS")


### PR DESCRIPTION
## Describe the change
REPS and GEPS don't have a total intensity field so the sum of all types is used.

The minutely block also uses the intensity instead of accumulation to match the hourly forecast.

This change also better aligns the REPS and GEPS models with the GFS/GEFS models.

## Type of change

- [x] Bugfixes to existing code
- [ ] Breaking change
- [ ] New API Version
- [ ] General Improvement
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation Updates

## Checklist

- This pull request fixes issue: fixes #
- [x] Code builds locally. **Your pull request won't be merged unless tests pass**
- [x] Code has been formatted using ruff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added precipitation intensity support for REPS and GEPS data sources.
  - Intensity calculations now account for rain, snow, ice, and freezing rain components when available.

- **Bug Fixes**
  - Improved GEPS intensity calculations by using individual precipitation components.
  - REPS data is now refreshed sooner when it becomes stale, improving data freshness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->